### PR TITLE
[Feat & Bug] Core Tool Enhancements, Audit & Session Stats Panel / 核心工具增强、审核与会话统计面板

### DIFF
--- a/src/console/main.py
+++ b/src/console/main.py
@@ -1,7 +1,9 @@
 """ManualAid 控制台 -- 基于 Textual 的 TUI 工具"""
 
 import argparse
+import atexit
 import sys
+import time
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -35,7 +37,20 @@ def init_workspace(start_path: str | None = None) -> Workspace | None:
 
     workspace: Workspace = Workspace(str(folder_path))
     tool_registry.register(workspace)
+
+    session_id = workspace.db.create_session(name=f"session_{time.strftime('%Y%m%d_%H%M%S')}")
+    tool_registry.set_session_id(session_id)
+    workspace._current_session_id = session_id
+
+    atexit.register(_cleanup, workspace, session_id)
+
     return workspace
+
+
+def _cleanup(workspace: Workspace, session_id: int) -> None:
+    if session_id and hasattr(workspace, "db"):
+        workspace.db.close_session(session_id)
+        workspace.db.close()
 
 
 def main() -> None:

--- a/src/console/ui/repl.py
+++ b/src/console/ui/repl.py
@@ -188,6 +188,12 @@ class REPL(App):
         audit_committer = AuditCommitter(self.workspace)
         tui_console.audit_tab.set_committer(audit_committer)
 
+        # 注入统计标签页
+        tui_console.stats_tab.set_database(
+            self.workspace.db,
+            getattr(self.tool_registry, "_current_session_id", None),
+        )
+
         # 创建 command handler
         self.command_handler = CommandHandler(
             self.workspace,

--- a/src/console/ui/repl.py
+++ b/src/console/ui/repl.py
@@ -182,6 +182,12 @@ class REPL(App):
         title_right = self.query_one("#title-right", Label)
         title_right.update(f"工作区: {self.workspace.root_path}")
 
+        # 创建审核提交模块并注入审核标签页
+        from src.core.audit_committer import AuditCommitter
+
+        audit_committer = AuditCommitter(self.workspace)
+        tui_console.audit_tab.set_committer(audit_committer)
+
         # 创建 command handler
         self.command_handler = CommandHandler(
             self.workspace,

--- a/src/console/ui/repl.py
+++ b/src/console/ui/repl.py
@@ -278,6 +278,9 @@ class REPL(App):
 
     def action_quit_confirm(self) -> None:
         """退出应用"""
+        session_id = getattr(self.tool_registry, "_current_session_id", None)
+        if session_id is not None and hasattr(self.workspace, "db"):
+            self.workspace.db.close_session(session_id)
         if self.tui_console:
             self.tui_console.print("[bold]再见![/bold]")
         self.exit()

--- a/src/console/ui/tui_console.py
+++ b/src/console/ui/tui_console.py
@@ -9,6 +9,7 @@ from textual.containers import Vertical, Widget
 from textual.widgets import Collapsible, RichLog, Static, TabbedContent, TabPane
 
 from src.console.ui.widgets.audit_tab import AuditTab
+from src.console.ui.widgets.stats_tab import StatsTab
 
 
 class TuiConsole(Vertical):
@@ -18,6 +19,7 @@ class TuiConsole(Vertical):
     - Tab 1 (RichLog): 用于普通富文本日志.
     - Tab 2 (Tool Calls): 用于显示工具调用情况.
     - Tab 3 (Audit): 用于审核待处理的写入/编辑操作.
+    - Tab 4 (Statistics): 用于查看会话统计与工具使用排名.
     """
 
     DEFAULT_CSS = """
@@ -58,6 +60,8 @@ class TuiConsole(Vertical):
                 yield Vertical(id="tui-console-tool-calls")
             with TabPane("Audit", id="tab-audit"):
                 yield AuditTab()
+            with TabPane("Statistics", id="tab-stats"):
+                yield StatsTab()
 
     @property
     def main_log(self) -> RichLog:
@@ -70,6 +74,17 @@ class TuiConsole(Vertical):
     @property
     def audit_tab(self) -> AuditTab:
         return self.query_one(AuditTab)
+
+    @property
+    def stats_tab(self) -> StatsTab:
+        return self.query_one(StatsTab)
+
+    async def on_tabbed_content_tab_activated(self, event: TabbedContent.TabActivated) -> None:
+        """切换标签页时刷新内容."""
+        if event.pane.id == "tab-audit":
+            await self.audit_tab._refresh()
+        elif event.pane.id == "tab-stats":
+            await self.stats_tab._refresh()
 
     def print(self, *args) -> None:
         """将内容写入主日志区"""

--- a/src/console/ui/tui_console.py
+++ b/src/console/ui/tui_console.py
@@ -8,6 +8,8 @@ from rich.markdown import Markdown
 from textual.containers import Vertical, Widget
 from textual.widgets import Collapsible, RichLog, Static, TabbedContent, TabPane
 
+from src.console.ui.widgets.audit_tab import AuditTab
+
 
 class TuiConsole(Vertical):
     """功能完备的 TUI 控制台组件.
@@ -15,6 +17,7 @@ class TuiConsole(Vertical):
     包含:
     - Tab 1 (RichLog): 用于普通富文本日志.
     - Tab 2 (Tool Calls): 用于显示工具调用情况.
+    - Tab 3 (Audit): 用于审核待处理的写入/编辑操作.
     """
 
     DEFAULT_CSS = """
@@ -53,6 +56,8 @@ class TuiConsole(Vertical):
                 yield RichLog(id="tui-console-main-log", highlight=True, markup=True, wrap=True)
             with TabPane("Tool Calls", id="tab-tool-calls"):
                 yield Vertical(id="tui-console-tool-calls")
+            with TabPane("Audit", id="tab-audit"):
+                yield AuditTab()
 
     @property
     def main_log(self) -> RichLog:
@@ -61,6 +66,10 @@ class TuiConsole(Vertical):
     @property
     def tool_calls_container(self) -> Vertical:
         return self.query_one("#tui-console-tool-calls", Vertical)
+
+    @property
+    def audit_tab(self) -> AuditTab:
+        return self.query_one(AuditTab)
 
     def print(self, *args) -> None:
         """将内容写入主日志区"""

--- a/src/console/ui/widgets/audit_tab.py
+++ b/src/console/ui/widgets/audit_tab.py
@@ -1,0 +1,190 @@
+"""审核标签页 — 显示待审核的文件快照."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar
+
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Collapsible, Label, Static
+
+
+class AuditTab(Vertical):
+    """审核标签页.
+
+    显示所有 PENDING_AUDIT 的文件快照，
+    每个文件作为一个可折叠块，含 diff 内容和批准/拒绝按钮。
+    """
+
+    DEFAULT_CSS: ClassVar[str] = """
+    AuditTab {
+        height: 1fr;
+        width: 1fr;
+        padding: 0 1;
+    }
+
+    #audit-placeholder {
+        height: 100%;
+        content-align: center middle;
+        color: $text-muted;
+    }
+
+    #audit-empty {
+        height: 100%;
+        content-align: center middle;
+        color: $text-muted;
+    }
+
+    #audit-header {
+        height: auto;
+        padding: 1 0;
+        text-style: bold;
+        color: $text;
+    }
+
+    .audit-collapsible {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    .audit-diff {
+        height: auto;
+        padding: 1;
+        background: $surface;
+        border: solid $primary;
+        margin-bottom: 1;
+        font-family: monospace;
+    }
+
+    .audit-buttons {
+        height: auto;
+        align: left middle;
+        margin-bottom: 1;
+    }
+
+    .audit-approve {
+        margin-right: 1;
+    }
+
+    .audit-reject {
+        margin-right: 1;
+    }
+
+    #audit-result-log {
+        height: auto;
+        max-height: 6;
+        overflow-y: auto;
+        border: solid $accent;
+        padding: 0 1;
+        margin-bottom: 1;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._committer = None
+
+    def compose(self):
+        yield Label("正在加载审核列表...", id="audit-placeholder")
+
+    def set_committer(self, committer) -> None:
+        """设置审核提交模块并刷新列表."""
+        self._committer = committer
+        self._refresh()
+
+    def on_mount(self) -> None:
+        """控件挂载后刷新."""
+        if self._committer is not None:
+            # 延迟一下让 UI 就绪
+            self.set_timer(0.1, self._refresh)
+
+    def _refresh(self) -> None:
+        """查询待审核列表并重建 UI."""
+        if self._committer is None:
+            return
+
+        self.remove_children()
+
+        pending = self._committer.workspace.db.get_snapshots_by_audit_status("PENDING_AUDIT")
+
+        if not pending:
+            self.mount(Label("没有待审核的更改。", id="audit-empty"))
+            return
+
+        # Group by file_path
+        grouped: defaultdict[str, list[tuple]] = defaultdict(list)
+        for snap in pending:
+            grouped[snap[1]].append(snap)
+
+        # Result area for showing commit results
+        result_log = Vertical(id="audit-result-log")
+        self.mount(result_log)
+
+        header = Label(
+            f"待审核更改 ({sum(len(snaps) for snaps in grouped.values())} 项)",
+            id="audit-header",
+        )
+        self.mount(header)
+
+        for file_path in sorted(grouped):
+            snaps = grouped[file_path]
+            # Use first snapshot's id for the collapsible key
+            content_widgets = Vertical()
+            for snap in snaps:
+                snap_id = snap[0]
+                diff_content = snap[4] or "(空 diff)"
+
+                diff_static = Static(diff_content, classes="audit-diff")
+                btn_row = Horizontal(
+                    Button("批准", variant="primary", id=f"approve-{snap_id}", classes="audit-approve"),
+                    Button("拒绝", variant="error", id=f"reject-{snap_id}", classes="audit-reject"),
+                    classes="audit-buttons",
+                )
+                content_widgets.mount(diff_static)
+                content_widgets.mount(btn_row)
+
+            collapsible = Collapsible(
+                content_widgets,
+                title=f"{file_path} ({len(snaps)} 次更改)",
+                classes="audit-collapsible",
+            )
+            # Collapse excess items initially — keep first 3 expanded
+            if len(self.children) > 6:  # header + result_log + 3 expanded
+                collapsible.collapsed = True
+            self.mount(collapsible)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """处理批准/拒绝按钮点击."""
+        if self._committer is None:
+            return
+
+        button_id = event.button.id or ""
+
+        parts = button_id.split("-", 1)
+        if len(parts) != 2:
+            return
+
+        action, snap_id_str = parts
+        try:
+            snapshot_id = int(snap_id_str)
+        except ValueError:
+            return
+
+        if action == "approve":
+            result = self._committer.commit(snapshot_id, approved=True)
+        elif action == "reject":
+            result = self._committer.commit(snapshot_id, approved=False)
+        else:
+            return
+
+        # Show result in the result log
+        try:
+            log = self.query_one("#audit-result-log", Vertical)
+
+            color = "green" if "已批准" in result or "已拒绝" in result else "red"
+            log.mount(Static(f"[{color}]{result}[/{color}]"))
+        except Exception:
+            pass
+
+        # Refresh the list
+        self._refresh()

--- a/src/console/ui/widgets/audit_tab.py
+++ b/src/console/ui/widgets/audit_tab.py
@@ -50,6 +50,8 @@ class AuditTab(Vertical):
 
     .audit-diff {
         height: auto;
+        max-height: 15;
+        overflow-y: auto;
         padding: 1;
         background: $surface;
         border: solid $primary;
@@ -134,13 +136,13 @@ class AuditTab(Vertical):
                 snap_id = snap[0]
                 diff_content = snap[4] or "(空 diff)"
 
-                diff_static = Static(diff_content, classes="audit-diff")
+                diff_container = Vertical(Static(diff_content), classes="audit-diff")
                 btn_row = Horizontal(
                     Button("批准", variant="primary", id=f"approve-{snap_id}", classes="audit-approve"),
                     Button("拒绝", variant="error", id=f"reject-{snap_id}", classes="audit-reject"),
                     classes="audit-buttons",
                 )
-                all_snap_widgets.append(diff_static)
+                all_snap_widgets.append(diff_container)
                 all_snap_widgets.append(btn_row)
 
             content_widgets = Vertical(*all_snap_widgets)

--- a/src/console/ui/widgets/audit_tab.py
+++ b/src/console/ui/widgets/audit_tab.py
@@ -21,6 +21,7 @@ class AuditTab(Vertical):
         height: 1fr;
         width: 1fr;
         padding: 0 1;
+        overflow-y: auto;
     }
 
     #audit-placeholder {
@@ -107,7 +108,7 @@ class AuditTab(Vertical):
         pending = self._committer.workspace.db.get_snapshots_by_audit_status("PENDING_AUDIT")
 
         if not pending:
-            self.mount(Label("没有待审核的更改.", id="audit-empty"))
+            await self.mount(Label("没有待审核的更改.", id="audit-empty"))
             return
 
         # Group by file_path
@@ -117,13 +118,13 @@ class AuditTab(Vertical):
 
         # Result area for showing commit results
         result_log = Vertical(id="audit-result-log")
-        self.mount(result_log)
+        await self.mount(result_log)
 
         header = Label(
             f"待审核更改 ({sum(len(snaps) for snaps in grouped.values())} 项)",
             id="audit-header",
         )
-        self.mount(header)
+        await self.mount(header)
 
         for file_path in sorted(grouped):
             snaps = grouped[file_path]
@@ -152,7 +153,7 @@ class AuditTab(Vertical):
             # Collapse excess items initially — keep first 3 expanded
             if len(self.children) > 6:  # header + result_log + 3 expanded
                 collapsible.collapsed = True
-            self.mount(collapsible)
+            await self.mount(collapsible)
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         """处理批准/拒绝按钮点击."""
@@ -183,7 +184,7 @@ class AuditTab(Vertical):
             log = self.query_one("#audit-result-log", Vertical)
 
             color = "green" if "已批准" in result or "已拒绝" in result else "red"
-            log.mount(Static(f"[{color}]{result}[/{color}]"))
+            await log.mount(Static(f"[{color}]{result}[/{color}]"))
         except Exception:
             pass
 

--- a/src/console/ui/widgets/audit_tab.py
+++ b/src/console/ui/widgets/audit_tab.py
@@ -12,8 +12,8 @@ from textual.widgets import Button, Collapsible, Label, Static
 class AuditTab(Vertical):
     """审核标签页.
 
-    显示所有 PENDING_AUDIT 的文件快照，
-    每个文件作为一个可折叠块，含 diff 内容和批准/拒绝按钮。
+    显示所有 PENDING_AUDIT 的文件快照,
+    每个文件作为一个可折叠块,含 diff 内容和批准/拒绝按钮.
     """
 
     DEFAULT_CSS: ClassVar[str] = """
@@ -53,7 +53,6 @@ class AuditTab(Vertical):
         background: $surface;
         border: solid $primary;
         margin-bottom: 1;
-        font-family: monospace;
     }
 
     .audit-buttons {
@@ -90,7 +89,7 @@ class AuditTab(Vertical):
     def set_committer(self, committer) -> None:
         """设置审核提交模块并刷新列表."""
         self._committer = committer
-        self._refresh()
+        self.set_timer(0.0, self._refresh)
 
     def on_mount(self) -> None:
         """控件挂载后刷新."""
@@ -98,17 +97,17 @@ class AuditTab(Vertical):
             # 延迟一下让 UI 就绪
             self.set_timer(0.1, self._refresh)
 
-    def _refresh(self) -> None:
+    async def _refresh(self) -> None:
         """查询待审核列表并重建 UI."""
         if self._committer is None:
             return
 
-        self.remove_children()
+        await self.remove_children()
 
         pending = self._committer.workspace.db.get_snapshots_by_audit_status("PENDING_AUDIT")
 
         if not pending:
-            self.mount(Label("没有待审核的更改。", id="audit-empty"))
+            self.mount(Label("没有待审核的更改.", id="audit-empty"))
             return
 
         # Group by file_path
@@ -128,8 +127,8 @@ class AuditTab(Vertical):
 
         for file_path in sorted(grouped):
             snaps = grouped[file_path]
-            # Use first snapshot's id for the collapsible key
-            content_widgets = Vertical()
+            # Collect all children for all snaps of this file
+            all_snap_widgets: list[Static | Horizontal] = []
             for snap in snaps:
                 snap_id = snap[0]
                 diff_content = snap[4] or "(空 diff)"
@@ -140,8 +139,10 @@ class AuditTab(Vertical):
                     Button("拒绝", variant="error", id=f"reject-{snap_id}", classes="audit-reject"),
                     classes="audit-buttons",
                 )
-                content_widgets.mount(diff_static)
-                content_widgets.mount(btn_row)
+                all_snap_widgets.append(diff_static)
+                all_snap_widgets.append(btn_row)
+
+            content_widgets = Vertical(*all_snap_widgets)
 
             collapsible = Collapsible(
                 content_widgets,
@@ -153,7 +154,7 @@ class AuditTab(Vertical):
                 collapsible.collapsed = True
             self.mount(collapsible)
 
-    def on_button_pressed(self, event: Button.Pressed) -> None:
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
         """处理批准/拒绝按钮点击."""
         if self._committer is None:
             return
@@ -187,4 +188,4 @@ class AuditTab(Vertical):
             pass
 
         # Refresh the list
-        self._refresh()
+        await self._refresh()

--- a/src/console/ui/widgets/stats_tab.py
+++ b/src/console/ui/widgets/stats_tab.py
@@ -1,0 +1,371 @@
+"""Statistics tab — session stats, tool ranking, session management."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, DataTable, Input, Label, Static
+
+
+class RenameDialog(ModalScreen[str | None]):
+    """Modal dialog for renaming a session."""
+
+    DEFAULT_CSS = """
+    RenameDialog {
+        align: center middle;
+    }
+
+    #rename-dialog {
+        width: 40;
+        height: auto;
+        padding: 2;
+        border: thick $primary;
+        background: $surface;
+    }
+
+    #rename-dialog > Label {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    #rename-input {
+        margin-bottom: 1;
+    }
+
+    #rename-buttons {
+        height: auto;
+        align: right middle;
+    }
+
+    #rename-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self, session_id: int, current_name: str) -> None:
+        super().__init__()
+        self._session_id = session_id
+        self._current_name = current_name
+
+    def compose(self):
+        with Vertical(id="rename-dialog"):
+            yield Label("Rename Session")
+            yield Input(value=self._current_name, id="rename-input")
+            with Horizontal(id="rename-buttons"):
+                yield Button("Cancel", id="cancel-btn", variant="default")
+                yield Button("OK", id="ok-btn", variant="primary")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "ok-btn":
+            new_name = self.query_one("#rename-input", Input).value
+            self.dismiss(new_name)
+        elif event.button.id == "cancel-btn":
+            self.dismiss(None)
+
+
+class QuestionDialog(ModalScreen[bool]):
+    """Simple yes/no confirmation dialog."""
+
+    DEFAULT_CSS = """
+    QuestionDialog {
+        align: center middle;
+    }
+
+    #question-dialog {
+        width: 50;
+        height: auto;
+        padding: 2;
+        border: thick $primary;
+        background: $surface;
+    }
+
+    #question-dialog > Label {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    #question-message {
+        margin-bottom: 1;
+    }
+
+    #question-buttons {
+        height: auto;
+        align: right middle;
+    }
+
+    #question-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self, title: str, message: str) -> None:
+        super().__init__()
+        self._title = title
+        self._message = message
+
+    def compose(self):
+        with Vertical(id="question-dialog"):
+            yield Label(self._title)
+            yield Label(self._message, id="question-message")
+            with Horizontal(id="question-buttons"):
+                yield Button("Cancel", id="cancel-btn", variant="default")
+                yield Button("OK", id="ok-btn", variant="primary")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "ok-btn":
+            self.dismiss(True)
+        elif event.button.id == "cancel-btn":
+            self.dismiss(False)
+
+
+class StatsTab(Vertical):
+    """Statistics & session management tab.
+
+    Displays:
+    - Overview (total sessions, calls, success rate)
+    - Current session stats (DataTable)
+    - Tool usage ranking (DataTable, top 10)
+    - Session list with rename/delete buttons.
+    """
+
+    DEFAULT_CSS: ClassVar[str] = """
+    StatsTab {
+        height: 1fr;
+        width: 1fr;
+        padding: 0 1;
+        overflow-y: auto;
+    }
+
+    #stats-placeholder {
+        height: 100%;
+        content-align: center middle;
+        color: $text-muted;
+    }
+
+    #stats-empty {
+        height: 100%;
+        content-align: center middle;
+        color: $text-muted;
+    }
+
+    .stats-header {
+        height: auto;
+        padding: 1 0;
+        text-style: bold;
+        color: $text;
+        border-bottom: solid $primary;
+    }
+
+    #stats-overview {
+        height: auto;
+        padding: 1;
+        background: $surface;
+        border: solid $primary;
+        margin-bottom: 1;
+    }
+
+    StatsTab DataTable {
+        height: auto;
+        max-height: 12;
+        margin-bottom: 1;
+    }
+
+    .stats-session-row {
+        height: auto;
+        padding: 0 0;
+        margin-bottom: 0;
+        align: left middle;
+    }
+
+    .stats-session-name {
+        width: 1fr;
+        height: auto;
+        padding: 0 1;
+    }
+
+    .stats-session-row Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._db = None
+        self._current_session_id: int | None = None
+
+    def compose(self):
+        yield Label("Loading statistics...", id="stats-placeholder")
+
+    def set_database(self, db, current_session_id: int | None) -> None:
+        """Set database reference and refresh."""
+        self._db = db
+        self._current_session_id = current_session_id
+        self.set_timer(0.0, self._refresh)
+
+    def on_mount(self) -> None:
+        if self._db is not None:
+            self.set_timer(0.1, self._refresh)
+
+    def _format_duration(self, seconds: float) -> str:
+        """Format seconds to human-readable string."""
+        if seconds < 60:
+            return f"{seconds:.0f}s"
+        minutes = int(seconds // 60)
+        secs = int(seconds % 60)
+        if minutes < 60:
+            return f"{minutes}m {secs}s"
+        hours = minutes // 60
+        minutes = minutes % 60
+        return f"{hours}h {minutes}m {secs}s"
+
+    async def _refresh(self) -> None:
+        """Rebuild the entire stats UI."""
+        if self._db is None:
+            return
+
+        await self.remove_children()
+        self._build_content()
+
+    def _build_content(self) -> None:
+        """Mount all content widgets."""
+        if self._db is None:
+            return
+
+        sessions = self._db.get_all_sessions()
+        total_sessions = len(sessions)
+
+        # Compute global aggregates
+        total_calls = 0
+        total_success = 0
+        for s in sessions:
+            sid = s[0]
+            summary = self._db.get_session_summary(sid)
+            total_calls += summary["total_calls"]
+            total_success += summary["success_count"]
+
+        success_rate = (total_success / total_calls * 100) if total_calls else 0.0
+
+        # Current session name
+        current_name = ""
+        if self._current_session_id is not None:
+            row = self._db.fetchone(
+                "SELECT name FROM sessions WHERE id = ?",
+                (self._current_session_id,),
+            )
+            if row:
+                current_name = row[0]
+
+        # --- Section 1: Overview ---
+        overview_text = (
+            f"[bold]Overview[/bold]\n"
+            f"Total Sessions: {total_sessions}\n"
+            f"Total Tool Calls: {total_calls}\n"
+            f"Overall Success Rate: {success_rate:.1f}%\n"
+            f"Active Session: {current_name or 'N/A'}"
+        )
+        self.mount(Static(overview_text, id="stats-overview"))
+
+        # --- Section 2: Current session stats ---
+        if self._current_session_id is not None:
+            summary = self._db.get_session_summary(self._current_session_id)
+            if summary:
+                duration_str = self._format_duration(summary["duration"])
+                self.mount(Label("Current Session", classes="stats-header"))
+                dt = DataTable(id="stats-current-session")
+                dt.add_columns("Metric", "Value")
+                dt.add_row("Duration", duration_str)
+                dt.add_row("Total Calls", str(summary["total_calls"]))
+                dt.add_row("Successful", str(summary["success_count"]))
+                dt.add_row("Failed", str(summary["fail_count"]))
+                dt.add_row("Success Rate", f"{summary['success_rate']:.1f}%")
+                self.mount(dt)
+
+        # --- Section 3: Tool usage ranking ---
+        ranking = self._db.get_tool_usage_ranking(self._current_session_id)
+        if ranking:
+            self.mount(Label("Top Tools", classes="stats-header"))
+            dt = DataTable(id="stats-tool-ranking")
+            dt.add_columns("#", "Tool", "Calls", "Avg Time")
+            for i, (func_name, count, avg_dur) in enumerate(ranking, 1):
+                avg_str = f"{avg_dur:.1f}ms" if avg_dur else "N/A"
+                dt.add_row(str(i), func_name, str(count), avg_str)
+            self.mount(dt)
+        else:
+            self.mount(Label("No tool calls recorded yet.", id="stats-empty"))
+
+        # --- Section 4: Session list ---
+        if sessions:
+            self.mount(Label("Sessions", classes="stats-header"))
+            for s in sessions:
+                sid, name, _created_at, duration = s
+                is_active = sid == self._current_session_id
+                name_display = name or "Unnamed"
+                if is_active:
+                    name_display += "  (active)"
+
+                duration_str = self._format_duration(duration) if duration else "in progress"
+
+                row = Horizontal(
+                    Static(f"{name_display}  [{duration_str}]", classes="stats-session-name"),
+                    Button("Rename", id=f"rename-{sid}", variant="default"),
+                    Button("Delete", id=f"delete-{sid}", variant="error"),
+                    classes="stats-session-row",
+                )
+                self.mount(row)
+                if is_active:
+                    row.query_one(f"#delete-{sid}", Button).disabled = True
+
+    async def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle rename/delete button clicks."""
+        if self._db is None:
+            return
+
+        button_id = event.button.id or ""
+
+        parts = button_id.split("-", 1)
+        if len(parts) != 2:
+            return
+
+        action, sid_str = parts
+        try:
+            session_id = int(sid_str)
+        except ValueError:
+            return
+
+        if action == "rename":
+            # Get current name
+            row = self._db.fetchone(
+                "SELECT name FROM sessions WHERE id = ?",
+                (session_id,),
+            )
+            current_name = row[0] if row else ""
+
+            async def on_rename(result: str | None) -> None:
+                if result is not None and result.strip():
+                    self._db.rename_session(session_id, result.strip())
+                    await self._refresh()
+                elif result is not None:
+                    self.notify("Name cannot be empty.", severity="warning")
+
+            self.app.push_screen(RenameDialog(session_id, current_name), on_rename)
+
+        elif action == "delete":
+            if session_id == self._current_session_id:
+                self.notify("Cannot delete the active session.", severity="error")
+                return
+
+            async def on_confirm(result: bool | None) -> None:
+                if result:
+                    self._db.delete_session(session_id)
+                    await self._refresh()
+
+            self.app.push_screen(
+                QuestionDialog(
+                    "Delete Session",
+                    f"Are you sure you want to delete session '{session_id}'?\n"
+                    "All tool calls and snapshots for this session will also be deleted.",
+                ),
+                on_confirm,
+            )

--- a/src/console/ui/widgets/stats_tab.py
+++ b/src/console/ui/widgets/stats_tab.py
@@ -207,6 +207,29 @@ class StatsTab(Vertical):
     def on_mount(self) -> None:
         if self._db is not None:
             self.set_timer(0.1, self._refresh)
+        self.set_interval(1.0, self._update_live_duration)
+
+    def _update_live_duration(self) -> None:
+        """Update current session duration display every second."""
+        if self._db is None or self._current_session_id is None:
+            return
+        try:
+            dt = self.query_one("#stats-current-session", DataTable)
+        except Exception:
+            return
+
+        row = self._db.fetchone(
+            "SELECT created_at FROM sessions WHERE id = ?",
+            (self._current_session_id,),
+        )
+        if not row:
+            return
+
+        import time
+
+        duration = time.time() - row[0]
+        duration_str = self._format_duration(duration)
+        dt.update_cell_at((0, 1), duration_str)
 
     def _format_duration(self, seconds: float) -> str:
         """Format seconds to human-readable string."""

--- a/src/console/ui/widgets/tools_result_widget.py
+++ b/src/console/ui/widgets/tools_result_widget.py
@@ -99,7 +99,7 @@ class ToolsResultWidget(Vertical):
             return
 
         try:
-            container = self.query_one("#tools-result-collapsibles", Vertical)
+            container = self.query_one("#tools-result-collapsible", Vertical)
         except Exception:
             return
 

--- a/src/constants/manual_aid.py
+++ b/src/constants/manual_aid.py
@@ -2,6 +2,7 @@
 
 # .ManualAid 目录名
 MANUALAID_DIR = ".ManualAid"
+DB_FILE = "manualaid.db"
 
 # 会话子目录
 SESSIONS_DIR = "sessions"

--- a/src/core/audit_committer.py
+++ b/src/core/audit_committer.py
@@ -6,16 +6,16 @@ from src.workspace.workspace import Workspace
 class AuditCommitter:
     """审核提交模块 — 处理待审核的写入/编辑操作.
 
-    不是 LLM 工具，供审核 UI 标签页调用。
-    新文件使用 create_file_with_parents() 创建并写入，
-    已有文件进行 mtime 校验后通过 write_text() 写入。
+    不是 LLM 工具,供审核 UI 标签页调用.
+    新文件使用 create_file_with_parents() 创建并写入,
+    已有文件进行 mtime 校验后通过 write_text() 写入.
     """
 
     def __init__(self, workspace: Workspace):
         self.workspace = workspace
 
     def commit(self, snapshot_id: int, approved: bool = True) -> str:
-        """执行审核结果。
+        """执行审核结果.
 
         Args:
             snapshot_id: 文件快照 ID
@@ -66,7 +66,7 @@ class AuditCommitter:
                     stored_mtime = record[2]
                     current_mtime = resolved.stat().st_mtime
                     if abs(current_mtime - stored_mtime) > 0.001:
-                        return f"ERROR: 文件已被外部修改，审核终止: {rel_path}。请重新读取后再批准。"
+                        return f"ERROR: 文件已被外部修改,审核终止: {rel_path}.请重新读取后再批准."
                 resolved.write_text(pending_content, encoding="utf-8")
 
             # 4. 更新 file_read_records

--- a/src/core/audit_committer.py
+++ b/src/core/audit_committer.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+
+from src.workspace.workspace import Workspace
+
+
+class AuditCommitter:
+    """审核提交模块 — 处理待审核的写入/编辑操作.
+
+    不是 LLM 工具，供审核 UI 标签页调用。
+    新文件使用 create_file_with_parents() 创建并写入，
+    已有文件进行 mtime 校验后通过 write_text() 写入。
+    """
+
+    def __init__(self, workspace: Workspace):
+        self.workspace = workspace
+
+    def commit(self, snapshot_id: int, approved: bool = True) -> str:
+        """执行审核结果。
+
+        Args:
+            snapshot_id: 文件快照 ID
+            approved: True=批准写入, False=拒绝
+
+        Returns:
+            操作结果消息
+        """
+        db = self.workspace.db
+
+        # 1. 获取快照
+        snap = db.get_snapshot_by_id(snapshot_id)
+        if snap is None:
+            return f"快照不存在: {snapshot_id}"
+
+        (
+            _snap_id,
+            file_path,
+            _old_hash,
+            _new_hash,
+            _diff_content,
+            _timestamp,
+            _session_id,
+            audit_status,
+            pending_content,
+        ) = snap
+
+        # 2. 检查状态
+        if audit_status != "PENDING_AUDIT":
+            return f"快照已处理 (当前状态: {audit_status})"
+
+        if not approved:
+            db.update_snapshot_audit(snapshot_id, "REJECTED")
+            return f"已拒绝 (snapshot_id={snapshot_id})"
+
+        # 3. 批准 — 执行写入
+        try:
+            resolved = self.workspace.path_validator.resolve_path(Path(file_path))
+
+            if not resolved.exists():
+                # 全新文件 — 使用 create_file_with_parents
+                self.workspace.path_validator.create_file_with_parents(resolved, pending_content)
+            else:
+                # 已有文件 — mtime 校验后 write_text
+                rel_path = str(resolved.relative_to(self.workspace.root_path))
+                record = db.get_file_read_record(rel_path)
+                if record is not None:
+                    stored_mtime = record[2]
+                    current_mtime = resolved.stat().st_mtime
+                    if abs(current_mtime - stored_mtime) > 0.001:
+                        return f"ERROR: 文件已被外部修改，审核终止: {rel_path}。请重新读取后再批准。"
+                resolved.write_text(pending_content, encoding="utf-8")
+
+            # 4. 更新 file_read_records
+            from src.core.file_tracker import FileTracker
+
+            rel_path = str(resolved.relative_to(self.workspace.root_path))
+            new_meta = FileTracker.get_file_meta(resolved)
+            if new_meta:
+                db.record_file_read(rel_path, new_meta["mtime"], new_meta["size"], new_meta["checksum"])
+
+            # 5. 更新审计状态
+            db.update_snapshot_audit(snapshot_id, "APPROVED")
+
+            return f"已批准并写入文件 (snapshot_id={snapshot_id})"
+
+        except Exception as e:
+            return f"写入失败: {e.__class__.__name__}({e})"

--- a/src/core/database_manager.py
+++ b/src/core/database_manager.py
@@ -252,6 +252,64 @@ class DatabaseManager:
             (status,),
         )
 
+    # -- Session statistics and management --
+
+    def get_session_summary(self, session_id: int) -> dict:
+        """Aggregated stats for a single session."""
+        session = self.fetchone(
+            "SELECT id, name, created_at, duration FROM sessions WHERE id = ?",
+            (session_id,),
+        )
+        if not session:
+            return {}
+
+        total = self.fetchone(
+            "SELECT COUNT(*), SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), "
+            "SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) "
+            "FROM tool_calls WHERE session_id = ?",
+            (session_id,),
+        )
+        total_calls, success_count, fail_count = total or (0, 0, 0)
+
+        return {
+            "id": session[0],
+            "name": session[1],
+            "created_at": session[2],
+            "duration": session[3],
+            "total_calls": total_calls or 0,
+            "success_count": success_count or 0,
+            "fail_count": fail_count or 0,
+            "success_rate": (success_count / total_calls * 100) if total_calls else 0.0,
+        }
+
+    def get_all_sessions(self) -> list[tuple]:
+        """All sessions ordered by created_at descending."""
+        return self.fetchall("SELECT id, name, created_at, duration FROM sessions ORDER BY created_at DESC")
+
+    def rename_session(self, session_id: int, name: str) -> None:
+        self.execute("UPDATE sessions SET name = ? WHERE id = ?", (name, session_id))
+
+    def delete_session(self, session_id: int) -> None:
+        self.execute("DELETE FROM tool_calls WHERE session_id = ?", (session_id,))
+        self.execute("DELETE FROM file_snapshots WHERE session_id = ?", (session_id,))
+        self.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
+
+    def get_tool_usage_ranking(self, session_id: int | None = None, limit: int = 10) -> list[tuple]:
+        """Returns list of (func_name, call_count, avg_duration_ms) ordered by count DESC."""
+        if session_id is not None:
+            return self.fetchall(
+                "SELECT func_name, COUNT(*) as cnt, AVG(duration_ms) as avg_dur "
+                "FROM tool_calls WHERE session_id = ? "
+                "GROUP BY func_name ORDER BY cnt DESC LIMIT ?",
+                (session_id, limit),
+            )
+        return self.fetchall(
+            "SELECT func_name, COUNT(*) as cnt, AVG(duration_ms) as avg_dur "
+            "FROM tool_calls "
+            "GROUP BY func_name ORDER BY cnt DESC LIMIT ?",
+            (limit,),
+        )
+
     # -- Class-level cleanup for testing --
 
     @classmethod

--- a/src/core/database_manager.py
+++ b/src/core/database_manager.py
@@ -104,6 +104,17 @@ class DatabaseManager:
         )
         conn.commit()
 
+        # Phase 2 migration: add pending_content column to file_snapshots
+        self._migrate_add_pending_content(conn)
+
+    @staticmethod
+    def _migrate_add_pending_content(conn: sqlite3.Connection) -> None:
+        try:
+            conn.execute("ALTER TABLE file_snapshots ADD COLUMN pending_content TEXT NOT NULL DEFAULT ''")
+            conn.commit()
+        except sqlite3.OperationalError:
+            pass  # Column already exists
+
     def close(self) -> None:
         if hasattr(self._thread_local, "connection") and self._thread_local.connection is not None:
             self._thread_local.connection.close()
@@ -205,12 +216,13 @@ class DatabaseManager:
         diff_content: str,
         audit_status: str = "PENDING_AUDIT",
         session_id: int | None = None,
+        pending_content: str = "",
     ) -> int:
         cursor = self.execute(
             "INSERT INTO file_snapshots "
-            "(file_path, old_hash, new_hash, diff_content, timestamp, session_id, audit_status) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (file_path, old_hash, new_hash, diff_content, time.time(), session_id, audit_status),
+            "(file_path, old_hash, new_hash, diff_content, timestamp, session_id, audit_status, pending_content) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (file_path, old_hash, new_hash, diff_content, time.time(), session_id, audit_status, pending_content),
         )
         return cursor.lastrowid
 
@@ -222,8 +234,22 @@ class DatabaseManager:
 
     def get_pending_audits(self) -> list[tuple]:
         return self.fetchall(
-            "SELECT id, file_path, old_hash, new_hash, diff_content, timestamp, session_id, audit_status "
-            "FROM file_snapshots WHERE audit_status = 'PENDING_AUDIT'"
+            "SELECT id, file_path, old_hash, new_hash, diff_content, timestamp, session_id, audit_status"
+            " FROM file_snapshots WHERE audit_status = 'PENDING_AUDIT'"
+        )
+
+    def get_snapshot_by_id(self, snapshot_id: int) -> tuple | None:
+        return self.fetchone(
+            "SELECT id, file_path, old_hash, new_hash, diff_content, timestamp, session_id, audit_status,"
+            " pending_content FROM file_snapshots WHERE id = ?",
+            (snapshot_id,),
+        )
+
+    def get_snapshots_by_audit_status(self, status: str) -> list[tuple]:
+        return self.fetchall(
+            "SELECT id, file_path, old_hash, new_hash, diff_content, timestamp, session_id, audit_status,"
+            " pending_content FROM file_snapshots WHERE audit_status = ?",
+            (status,),
         )
 
     # -- Class-level cleanup for testing --

--- a/src/core/database_manager.py
+++ b/src/core/database_manager.py
@@ -1,0 +1,236 @@
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import ClassVar
+
+from src.constants.manual_aid import DB_FILE, MANUALAID_DIR
+
+
+class DatabaseManager:
+    """Thread-safe SQLite3 database manager (singleton per workspace path)."""
+
+    _instances: ClassVar[dict[str, "DatabaseManager"]] = {}
+    _instance_lock: ClassVar[threading.Lock] = threading.Lock()
+
+    def __new__(cls, workspace_root: str) -> "DatabaseManager":
+        with cls._instance_lock:
+            if workspace_root not in cls._instances:
+                instance = super().__new__(cls)
+                instance._initialized = False
+                cls._instances[workspace_root] = instance
+        return cls._instances[workspace_root]
+
+    def __init__(self, workspace_root: str) -> None:
+        if self._initialized:
+            return
+
+        self._workspace_root = workspace_root
+        self._db_dir = Path(workspace_root) / MANUALAID_DIR
+        self._db_path = self._db_dir / DB_FILE
+        self._write_lock = threading.Lock()
+        self._thread_local = threading.local()
+
+        self._ensure_directory()
+        self._init_tables()
+        self._initialized = True
+
+    @property
+    def db_path(self) -> Path:
+        return self._db_path
+
+    def _ensure_directory(self) -> None:
+        self._db_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_connection(self) -> sqlite3.Connection:
+        if not hasattr(self._thread_local, "connection") or self._thread_local.connection is None:
+            conn = sqlite3.connect(str(self._db_path))
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA foreign_keys=ON")
+            conn.execute("PRAGMA busy_timeout=5000")
+            self._thread_local.connection = conn
+        return self._thread_local.connection
+
+    def _init_tables(self) -> None:
+        conn = self._get_connection()
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                name        TEXT NOT NULL DEFAULT '',
+                created_at  REAL NOT NULL,
+                duration    REAL NOT NULL DEFAULT 0.0
+            );
+
+            CREATE TABLE IF NOT EXISTS tool_calls (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id   INTEGER NOT NULL,
+                func_name    TEXT NOT NULL,
+                args_hash    TEXT NOT NULL DEFAULT '',
+                timestamp    REAL NOT NULL,
+                duration_ms  REAL NOT NULL DEFAULT 0.0,
+                status       TEXT NOT NULL DEFAULT 'success',
+                audit_status TEXT NOT NULL DEFAULT 'none',
+                FOREIGN KEY (session_id) REFERENCES sessions(id)
+            );
+
+            CREATE TABLE IF NOT EXISTS file_read_records (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path    TEXT NOT NULL UNIQUE,
+                mtime        REAL NOT NULL,
+                size         INTEGER NOT NULL DEFAULT 0,
+                checksum     TEXT NOT NULL DEFAULT '',
+                last_read_at REAL NOT NULL,
+                read_count   INTEGER NOT NULL DEFAULT 1
+            );
+
+            CREATE TABLE IF NOT EXISTS file_snapshots (
+                id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path    TEXT NOT NULL,
+                old_hash     TEXT,
+                new_hash     TEXT NOT NULL,
+                diff_content TEXT NOT NULL DEFAULT '',
+                timestamp    REAL NOT NULL,
+                session_id   INTEGER,
+                audit_status TEXT NOT NULL DEFAULT 'PENDING_AUDIT',
+                FOREIGN KEY (session_id) REFERENCES sessions(id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id);
+            CREATE INDEX IF NOT EXISTS idx_tool_calls_func ON tool_calls(func_name);
+            CREATE INDEX IF NOT EXISTS idx_file_read_records_path ON file_read_records(file_path);
+            CREATE INDEX IF NOT EXISTS idx_file_snapshots_audit ON file_snapshots(audit_status);
+            """
+        )
+        conn.commit()
+
+    def close(self) -> None:
+        if hasattr(self._thread_local, "connection") and self._thread_local.connection is not None:
+            self._thread_local.connection.close()
+            self._thread_local.connection = None
+
+    # -- Unified query interface --
+
+    def execute(self, sql: str, params: tuple = ()) -> sqlite3.Cursor:
+        with self._write_lock:
+            conn = self._get_connection()
+            cursor = conn.execute(sql, params)
+            conn.commit()
+            return cursor
+
+    def fetchone(self, sql: str, params: tuple = ()) -> tuple | None:
+        conn = self._get_connection()
+        cursor = conn.execute(sql, params)
+        return cursor.fetchone()
+
+    def fetchall(self, sql: str, params: tuple = ()) -> list[tuple]:
+        conn = self._get_connection()
+        cursor = conn.execute(sql, params)
+        return cursor.fetchall()
+
+    # -- Session lifecycle --
+
+    def create_session(self, name: str = "") -> int:
+        cursor = self.execute(
+            "INSERT INTO sessions (name, created_at) VALUES (?, ?)",
+            (name, time.time()),
+        )
+        return cursor.lastrowid
+
+    def close_session(self, session_id: int) -> None:
+        row = self.fetchone("SELECT created_at FROM sessions WHERE id = ?", (session_id,))
+        if row:
+            duration = time.time() - row[0]
+            self.execute(
+                "UPDATE sessions SET duration = ? WHERE id = ?",
+                (duration, session_id),
+            )
+
+    # -- Tool call logging --
+
+    def log_tool_call(
+        self,
+        session_id: int,
+        func_name: str,
+        args_hash: str,
+        duration_ms: float = 0.0,
+        status: str = "success",
+        audit_status: str = "none",
+    ) -> int:
+        cursor = self.execute(
+            "INSERT INTO tool_calls (session_id, func_name, args_hash, timestamp, duration_ms, status, audit_status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (session_id, func_name, args_hash, time.time(), duration_ms, status, audit_status),
+        )
+        return cursor.lastrowid
+
+    def update_tool_call_status(self, call_id: int, status: str, audit_status: str) -> None:
+        self.execute(
+            "UPDATE tool_calls SET status = ?, audit_status = ? WHERE id = ?",
+            (status, audit_status, call_id),
+        )
+
+    # -- File read records --
+
+    def record_file_read(self, file_path: str, mtime: float, size: int, checksum: str) -> None:
+        with self._write_lock:
+            conn = self._get_connection()
+            conn.execute(
+                "INSERT INTO file_read_records (file_path, mtime, size, checksum, last_read_at, read_count) "
+                "VALUES (?, ?, ?, ?, ?, 1) "
+                "ON CONFLICT(file_path) DO UPDATE SET "
+                "mtime = excluded.mtime, "
+                "size = excluded.size, "
+                "checksum = excluded.checksum, "
+                "last_read_at = excluded.last_read_at, "
+                "read_count = read_count + 1",
+                (file_path, mtime, size, checksum, time.time()),
+            )
+            conn.commit()
+
+    def get_file_read_record(self, file_path: str) -> tuple | None:
+        return self.fetchone(
+            "SELECT id, file_path, mtime, size, checksum, last_read_at, read_count "
+            "FROM file_read_records WHERE file_path = ?",
+            (file_path,),
+        )
+
+    # -- File snapshots --
+
+    def record_file_snapshot(
+        self,
+        file_path: str,
+        old_hash: str | None,
+        new_hash: str,
+        diff_content: str,
+        audit_status: str = "PENDING_AUDIT",
+        session_id: int | None = None,
+    ) -> int:
+        cursor = self.execute(
+            "INSERT INTO file_snapshots "
+            "(file_path, old_hash, new_hash, diff_content, timestamp, session_id, audit_status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (file_path, old_hash, new_hash, diff_content, time.time(), session_id, audit_status),
+        )
+        return cursor.lastrowid
+
+    def update_snapshot_audit(self, snapshot_id: int, audit_status: str) -> None:
+        self.execute(
+            "UPDATE file_snapshots SET audit_status = ? WHERE id = ?",
+            (audit_status, snapshot_id),
+        )
+
+    def get_pending_audits(self) -> list[tuple]:
+        return self.fetchall(
+            "SELECT id, file_path, old_hash, new_hash, diff_content, timestamp, session_id, audit_status "
+            "FROM file_snapshots WHERE audit_status = 'PENDING_AUDIT'"
+        )
+
+    # -- Class-level cleanup for testing --
+
+    @classmethod
+    def reset_instances(cls) -> None:
+        with cls._instance_lock:
+            for instance in cls._instances.values():
+                instance.close()
+            cls._instances.clear()

--- a/src/core/file_tracker.py
+++ b/src/core/file_tracker.py
@@ -1,0 +1,33 @@
+import hashlib
+from pathlib import Path
+
+
+class FileTracker:
+    """Static utility methods for file mtime/checksum tracking."""
+
+    @staticmethod
+    def compute_checksum(file_path: Path) -> str:
+        """Compute BLAKE2b hex digest of file content. Returns '' on error."""
+        try:
+            content = file_path.read_bytes()
+            return hashlib.blake2b(content).hexdigest()
+        except (OSError, PermissionError):
+            return ""
+
+    @staticmethod
+    def compute_checksum_from_string(content: str) -> str:
+        """Compute BLAKE2b hex digest of a string."""
+        return hashlib.blake2b(content.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def get_file_meta(file_path: Path) -> dict:
+        """Return {mtime, size, checksum} for a file, or empty dict on failure."""
+        try:
+            stat = file_path.stat()
+            return {
+                "mtime": stat.st_mtime,
+                "size": stat.st_size,
+                "checksum": FileTracker.compute_checksum(file_path),
+            }
+        except (OSError, PermissionError):
+            return {}

--- a/src/core/tool_registry.py
+++ b/src/core/tool_registry.py
@@ -47,6 +47,7 @@ class ToolRegistry:
         self._tools: dict[str, BaseTool] = {}
         self._current_session_id: int | None = None
         self._workspace: Workspace | None = None
+        self._tool_categories: dict[str, str] = {}
         self._initialized = True
 
         # 配置常量 - 从环境变量读取,带默认值
@@ -93,9 +94,22 @@ class ToolRegistry:
         if len(name) > self.MAX_FUNC_NAME_LENGTH:
             warnings.warn(f"工具名称 '{name}' 超过 {self.MAX_FUNC_NAME_LENGTH} 字符", UserWarning, stacklevel=3)
 
+    def _set_tool_category(self, tool_name: str) -> None:
+        """根据工具名称设置分类。"""
+        if tool_name in {"glob", "ls", "regex_search", "exact_search", "stat", "read", "read_lines", "symbol_ref"}:
+            self._tool_categories[tool_name] = "query"
+        elif tool_name in {"write", "edit", "confirm_edit"}:
+            self._tool_categories[tool_name] = "edit"
+        elif tool_name == "git":
+            self._tool_categories[tool_name] = "dangerous"
+        else:
+            self._tool_categories[tool_name] = "query"
+
     def register(self, workspace: Workspace) -> None:
         """为工作区注册工具"""
+        from src.workspace.tools.edit_tool import EditTool
         from src.workspace.tools.exact_search_tool import ExactSearchTool
+        from src.workspace.tools.git_tool import GitTool
         from src.workspace.tools.glob_tool import GlobTool
         from src.workspace.tools.ls_tool import LsTool
         from src.workspace.tools.read_lines_tool import ReadLinesTool
@@ -117,6 +131,8 @@ class ToolRegistry:
             WriteTool,
             StatTool,
             SymbolRefTool,
+            EditTool,
+            GitTool,
         ):
             try:
                 tool = cls(workspace)
@@ -124,6 +140,7 @@ class ToolRegistry:
                     warnings.warn(f"工具{tool.name}没有注册功能回调和参数", stacklevel=2)
                     continue
                 self._tools[tool.name] = tool
+                self._set_tool_category(tool.name)
             except ValueError:
                 pass
 
@@ -234,7 +251,28 @@ class ToolRegistry:
             args_hash = self._compute_args_hash(kwargs)
             workspace = getattr(self, "_workspace", None)
             if workspace is not None:
-                workspace.db.log_tool_call(session_id, func_name, args_hash, duration_ms=duration_ms, status=status)
+                # Determine audit_status based on tool category
+                category = self._tool_categories.get(func_name, "query")
+                audit_status = "none"
+
+                if category == "dangerous" and func_name == "git":
+                    # Git: check if the specific command is safe
+                    from src.workspace.tools.git_tool import GitTool
+
+                    command_str = kwargs.get("command_str", "")
+                    if not GitTool.is_safe_command(command_str):
+                        audit_status = "PENDING_AUDIT"
+                elif category == "edit":
+                    audit_status = "none"  # Snapshot has its own PENDING_AUDIT
+
+                workspace.db.log_tool_call(
+                    session_id,
+                    func_name,
+                    args_hash,
+                    duration_ms=duration_ms,
+                    status=status,
+                    audit_status=audit_status,
+                )
         except Exception:
             pass
         return f"ToolRegistry(sync_tools={len(self._tools)})"

--- a/src/core/tool_registry.py
+++ b/src/core/tool_registry.py
@@ -95,7 +95,7 @@ class ToolRegistry:
             warnings.warn(f"工具名称 '{name}' 超过 {self.MAX_FUNC_NAME_LENGTH} 字符", UserWarning, stacklevel=3)
 
     def _set_tool_category(self, tool_name: str) -> None:
-        """根据工具名称设置分类。"""
+        """根据工具名称设置分类."""
         if tool_name in {"glob", "ls", "regex_search", "exact_search", "stat", "read", "read_lines", "symbol_ref"}:
             self._tool_categories[tool_name] = "query"
         elif tool_name in {"write", "edit", "confirm_edit"}:

--- a/src/core/tool_registry.py
+++ b/src/core/tool_registry.py
@@ -1,7 +1,10 @@
 import asyncio
+import hashlib
 import inspect
+import json
 import os
 import threading
+import time
 import warnings
 from collections.abc import Awaitable, Callable
 from typing import Any, ClassVar, ParamSpec, Self, TypeVar
@@ -42,6 +45,8 @@ class ToolRegistry:
             return
 
         self._tools: dict[str, BaseTool] = {}
+        self._current_session_id: int | None = None
+        self._workspace: Workspace | None = None
         self._initialized = True
 
         # 配置常量 - 从环境变量读取,带默认值
@@ -99,6 +104,8 @@ class ToolRegistry:
         from src.workspace.tools.stat_tool import StatTool
         from src.workspace.tools.symbol_ref_tool import SymbolRefTool
         from src.workspace.tools.write_tool import WriteTool
+
+        self._workspace = workspace
 
         for cls in (
             ExactSearchTool,
@@ -158,6 +165,8 @@ class ToolRegistry:
             tool = self._tools[func_name]
             kwargs = tool.convert_args(kwargs)
 
+            start_time = time.perf_counter()
+            status = "success"
             try:
                 if inspect.iscoroutinefunction(tool.func):
                     coro = tool.func(*args, **kwargs)
@@ -173,7 +182,11 @@ class ToolRegistry:
                     # 同步函数
                     result = tool.func(*args, **kwargs)
             except Exception as e:
+                status = "error"
                 result = f'<func_name="{tool.name}", errors={e.__class__.__name__}({e})>'
+
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            self._log_tool_call(func_name, kwargs, duration_ms, status)
 
             return self._compress_result(result)
         else:
@@ -204,5 +217,24 @@ class ToolRegistry:
         """获取工具信息"""
         return self._tools.get(name)
 
-    def __repr__(self) -> str:
+    def set_session_id(self, session_id: int) -> None:
+        """设置当前会话 ID"""
+        self._current_session_id = session_id
+
+    @staticmethod
+    def _compute_args_hash(kwargs: dict) -> str:
+        sorted_json = json.dumps(kwargs, sort_keys=True, default=str)
+        return hashlib.blake2b(sorted_json.encode("utf-8")).hexdigest()
+
+    def _log_tool_call(self, func_name: str, kwargs: dict, duration_ms: float, status: str) -> None:
+        session_id = getattr(self, "_current_session_id", None)
+        if session_id is None:
+            return
+        try:
+            args_hash = self._compute_args_hash(kwargs)
+            workspace = getattr(self, "_workspace", None)
+            if workspace is not None:
+                workspace.db.log_tool_call(session_id, func_name, args_hash, duration_ms=duration_ms, status=status)
+        except Exception:
+            pass
         return f"ToolRegistry(sync_tools={len(self._tools)})"

--- a/src/core/tool_registry.py
+++ b/src/core/tool_registry.py
@@ -243,10 +243,10 @@ class ToolRegistry:
         sorted_json = json.dumps(kwargs, sort_keys=True, default=str)
         return hashlib.blake2b(sorted_json.encode("utf-8")).hexdigest()
 
-    def _log_tool_call(self, func_name: str, kwargs: dict, duration_ms: float, status: str) -> None:
+    def _log_tool_call(self, func_name: str, kwargs: dict, duration_ms: float, status: str) -> str | None:
         session_id = getattr(self, "_current_session_id", None)
         if session_id is None:
-            return
+            return None
         try:
             args_hash = self._compute_args_hash(kwargs)
             workspace = getattr(self, "_workspace", None)

--- a/src/workspace/tools/edit_tool.py
+++ b/src/workspace/tools/edit_tool.py
@@ -12,8 +12,8 @@ from src.workspace.workspace import Workspace
 class EditTool(BaseTool):
     """安全的字符串替换编辑工具 — 两阶段提交 (预览 → 审核确认).
 
-    只计算 diff 并记录 PENDING_AUDIT 快照，不直接修改磁盘。
-    由审核提交模块 (AuditCommitter) 在批准后执行实际写入。
+    只计算 diff 并记录 PENDING_AUDIT 快照,不直接修改磁盘.
+    由审核提交模块 (AuditCommitter) 在批准后执行实际写入.
     """
 
     def __init__(self, workspace: Workspace):
@@ -31,19 +31,19 @@ class EditTool(BaseTool):
         context_after: str = "",
     ) -> str:
         """
-        在文件中进行安全的字符串替换（仅预览，不修改磁盘）
+        在文件中进行安全的字符串替换(仅预览,不修改磁盘)
 
-        执行 dry-run 替换，生成 diff，记录 PENDING_AUDIT 快照。
-        批准后由 AuditCommitter 执行实际写入。
+        执行 dry-run 替换,生成 diff,记录 PENDING_AUDIT 快照.
+        批准后由 AuditCommitter 执行实际写入.
 
         Parameters
         ----------
         file_path: 文件路径
-        old_string: 待替换的字符串（不能为空）
+        old_string: 待替换的字符串(不能为空)
         new_string: 替换后的字符串
-        max_replacements: 最大替换次数（默认 10，最大 100）
-        context_before: 匹配前的上下文文本（可选，用于校验）
-        context_after: 匹配后的上下文文本（可选，用于校验）
+        max_replacements: 最大替换次数(默认 10,最大 100)
+        context_before: 匹配前的上下文文本(可选,用于校验)
+        context_after: 匹配后的上下文文本(可选,用于校验)
         """
         try:
             # 1. 参数校验
@@ -95,7 +95,7 @@ class EditTool(BaseTool):
                     f"No changes made: old_string not found in file.\nFile: {file_path}\nSearching for: '{old_string}'"
                 )
 
-            # 6. 执行替换（生成新内容）
+            # 6. 执行替换(生成新内容)
             new_content = old_content.replace(old_string, new_string, count)
 
             # 7. 生成 diff
@@ -166,7 +166,7 @@ class EditTool(BaseTool):
         context_after: str,
         match_number: int,
     ) -> str | None:
-        """校验匹配处的上下文是否与预期一致。"""
+        """校验匹配处的上下文是否与预期一致."""
         if context_before:
             actual_start = max(0, match_start - len(context_before))
             actual_before = content[actual_start:match_start]

--- a/src/workspace/tools/edit_tool.py
+++ b/src/workspace/tools/edit_tool.py
@@ -1,0 +1,204 @@
+"""安全的字符串替换编辑工具 — 只发布待审核更改."""
+
+import difflib
+from pathlib import Path
+
+from src.models.tool_error_response import ToolErrorResponse
+from src.workspace.path_validator import PathNotFoundError, WorkspaceBoundaryError
+from src.workspace.tools.base_tool import BaseTool
+from src.workspace.workspace import Workspace
+
+
+class EditTool(BaseTool):
+    """安全的字符串替换编辑工具 — 两阶段提交 (预览 → 审核确认).
+
+    只计算 diff 并记录 PENDING_AUDIT 快照，不直接修改磁盘。
+    由审核提交模块 (AuditCommitter) 在批准后执行实际写入。
+    """
+
+    def __init__(self, workspace: Workspace):
+        super().__init__(workspace, "edit", self.edit.__doc__, write_permission=True)
+        self.func = self.edit
+        self.params = BaseTool.extract_params(self.edit)
+
+    def edit(
+        self,
+        file_path: str,
+        old_string: str,
+        new_string: str,
+        max_replacements: int = 10,
+        context_before: str = "",
+        context_after: str = "",
+    ) -> str:
+        """
+        在文件中进行安全的字符串替换（仅预览，不修改磁盘）
+
+        执行 dry-run 替换，生成 diff，记录 PENDING_AUDIT 快照。
+        批准后由 AuditCommitter 执行实际写入。
+
+        Parameters
+        ----------
+        file_path: 文件路径
+        old_string: 待替换的字符串（不能为空）
+        new_string: 替换后的字符串
+        max_replacements: 最大替换次数（默认 10，最大 100）
+        context_before: 匹配前的上下文文本（可选，用于校验）
+        context_after: 匹配后的上下文文本（可选，用于校验）
+        """
+        try:
+            # 1. 参数校验
+            if not old_string:
+                return ToolErrorResponse(self.__class__.__name__, ValueError("old_string 不能为空")).to_str()
+
+            if max_replacements < 1:
+                return ToolErrorResponse(self.__class__.__name__, ValueError("max_replacements 必须 >= 1")).to_str()
+            if max_replacements > 100:
+                max_replacements = 100
+
+            # 2. 路径解析
+            source_file_path = Path(file_path)
+            resolved_path: Path = self.workspace.path_validator.resolve_path(source_file_path)
+
+            if not resolved_path.is_file():
+                return ToolErrorResponse(
+                    self.__class__.__name__,
+                    FileNotFoundError(f"文件不存在: {resolved_path}"),
+                ).to_str()
+
+            # 3. mtime 校验
+            mtime_error = self._validate_mtime(resolved_path)
+            if mtime_error:
+                return mtime_error
+
+            # 4. 读取文件内容
+            old_content = resolved_path.read_text(encoding="utf-8")
+
+            # 5. 查找匹配
+            count = 0
+            idx = 0
+            while count < max_replacements:
+                idx = old_content.find(old_string, idx)
+                if idx == -1:
+                    break
+                count += 1
+
+                # 上下文校验
+                if context_before or context_after:
+                    ctx_error = self._check_context(old_content, idx, old_string, context_before, context_after, count)
+                    if ctx_error:
+                        return ctx_error
+
+                idx += len(old_string)
+
+            if count == 0:
+                return (
+                    f"No changes made: old_string not found in file.\nFile: {file_path}\nSearching for: '{old_string}'"
+                )
+
+            # 6. 执行替换（生成新内容）
+            new_content = old_content.replace(old_string, new_string, count)
+
+            # 7. 生成 diff
+            rel_path = str(resolved_path.relative_to(self.workspace.root_path))
+            diff_content = self._generate_diff(old_content, new_content, rel_path)
+
+            # 8. 记录快照
+            from src.core.file_tracker import FileTracker
+
+            old_hash = FileTracker.compute_checksum_from_string(old_content)
+            new_hash = FileTracker.compute_checksum_from_string(new_content)
+            session_id = self.workspace._current_session_id
+            snapshot_id = self.workspace.db.record_file_snapshot(
+                rel_path,
+                old_hash,
+                new_hash,
+                diff_content,
+                audit_status="PENDING_AUDIT",
+                session_id=session_id,
+                pending_content=new_content,
+            )
+
+            # 9. 返回预览
+            return (
+                f"[Edit Preview]\n"
+                f"File: {rel_path}\n"
+                f"Snapshot ID: {snapshot_id}\n"
+                f"Replacements: {count}\n"
+                f"Diff:\n{diff_content}"
+            )
+
+        except PathNotFoundError as err1:
+            return ToolErrorResponse(self.__class__.__name__, err1).to_str()
+        except WorkspaceBoundaryError as err2:
+            return ToolErrorResponse(self.__class__.__name__, err2).to_str()
+        except PermissionError as err3:
+            return ToolErrorResponse(self.__class__.__name__, err3).to_str()
+        except Exception as err:
+            return ToolErrorResponse(self.__class__.__name__, err).to_str()
+
+    def _validate_mtime(self, resolved_path: Path) -> str | None:
+        """校验文件自上次读取后是否被外部修改."""
+        if not resolved_path.exists():
+            return None
+
+        rel_path = str(resolved_path.relative_to(self.workspace.root_path))
+        record = self.workspace.db.get_file_read_record(rel_path)
+        if record is None:
+            return None
+
+        stored_mtime = record[2]
+        current_mtime = resolved_path.stat().st_mtime
+
+        if abs(current_mtime - stored_mtime) > 0.001:
+            return (
+                f"ERROR: FILE_MODIFIED_EXTERNALLY - "
+                f'The file "{rel_path}" was modified externally since last read. '
+                f'Please re-read the file with the "read" tool before editing it.'
+            )
+        return None
+
+    @staticmethod
+    def _check_context(
+        content: str,
+        match_start: int,
+        old_string: str,
+        context_before: str,
+        context_after: str,
+        match_number: int,
+    ) -> str | None:
+        """校验匹配处的上下文是否与预期一致。"""
+        if context_before:
+            actual_start = max(0, match_start - len(context_before))
+            actual_before = content[actual_start:match_start]
+            if actual_before != context_before:
+                return ToolErrorResponse(
+                    "EditTool",
+                    ValueError(
+                        f"Match {match_number}: context_before mismatch.\n"
+                        f"  Expected: '{context_before}'\n"
+                        f"  Actual:   '{actual_before}'"
+                    ),
+                ).to_str()
+
+        if context_after:
+            after_start = match_start + len(old_string)
+            after_end = min(len(content), after_start + len(context_after))
+            actual_after = content[after_start:after_end]
+            if actual_after != context_after:
+                return ToolErrorResponse(
+                    "EditTool",
+                    ValueError(
+                        f"Match {match_number}: context_after mismatch.\n"
+                        f"  Expected: '{context_after}'\n"
+                        f"  Actual:   '{actual_after}'"
+                    ),
+                ).to_str()
+
+        return None
+
+    @staticmethod
+    def _generate_diff(old_content: str, new_content: str, file_path: str) -> str:
+        old_lines = old_content.splitlines(keepends=True)
+        new_lines = new_content.splitlines(keepends=True)
+        diff = difflib.unified_diff(old_lines, new_lines, fromfile=f"a/{file_path}", tofile=f"b/{file_path}")
+        return "".join(diff)

--- a/src/workspace/tools/git_tool.py
+++ b/src/workspace/tools/git_tool.py
@@ -1,4 +1,4 @@
-"""统一的 Git 工具 — 白名单机制，安全封装."""
+"""统一的 Git 工具 — 白名单机制,安全封装."""
 
 import re
 import shlex
@@ -8,10 +8,10 @@ from src.models.tool_error_response import ToolErrorResponse
 from src.workspace.tools.base_tool import BaseTool
 from src.workspace.workspace import Workspace
 
-# 安全命令（只读，直接执行，不需要审核）
+# 安全命令(只读,直接执行,不需要审核)
 _SAFE_COMMANDS = frozenset({"status", "diff", "log", "show"})
 
-# 白名单（所有允许的命令）
+# 白名单(所有允许的命令)
 _ALLOWED_COMMANDS = frozenset(
     {
         "status",
@@ -45,8 +45,8 @@ _BLOCKED_PATTERNS = [
 class GitTool(BaseTool):
     """统一的 Git 工具 — 安全的子命令执行.
 
-    白名单机制：
-    - 安全命令 (status, diff, log, show): 直接执行，不触发审核
+    白名单机制:
+    - 安全命令 (status, diff, log, show): 直接执行,不触发审核
     - 修改命令 (add, commit, restore, branch): 执行并标记 PENDING_AUDIT
     - 禁止命令 (push, reset --hard, merge, rebase, ...): 拦截并返回错误
     """
@@ -58,11 +58,11 @@ class GitTool(BaseTool):
 
     def git(self, command_str: str) -> str:
         """
-        执行 Git 命令（白名单限制）
+        执行 Git 命令(白名单限制)
 
         Parameters
         ----------
-        command_str: Git 子命令及其参数，如 "status"、"diff --cached"、"log --oneline -5"
+        command_str: Git 子命令及其参数,如 "status"、"diff --cached"、"log --oneline -5"
         """
         if not command_str or not command_str.strip():
             return ToolErrorResponse(self.__class__.__name__, ValueError("command_str 不能为空")).to_str()
@@ -100,14 +100,14 @@ class GitTool(BaseTool):
             if not non_flag_args:
                 return ToolErrorResponse(
                     self.__class__.__name__,
-                    ValueError("restore 需要指定文件路径，不允许裸 restore"),
+                    ValueError("restore 需要指定文件路径,不允许裸 restore"),
                 ).to_str()
             for arg in non_flag_args:
                 stripped = arg.strip()
                 if stripped in (".", "*", "all") or stripped.startswith("*"):
                     return ToolErrorResponse(
                         self.__class__.__name__,
-                        ValueError("restore 需要指定具体文件路径，不允许使用通配符"),
+                        ValueError("restore 需要指定具体文件路径,不允许使用通配符"),
                     ).to_str()
 
         # 4. 执行命令
@@ -127,7 +127,7 @@ class GitTool(BaseTool):
         except subprocess.TimeoutExpired:
             return ToolErrorResponse(
                 self.__class__.__name__,
-                TimeoutError("Git 命令执行超时（30 秒）"),
+                TimeoutError("Git 命令执行超时(30 秒)"),
             ).to_str()
 
         # 5. 处理输出
@@ -148,13 +148,13 @@ class GitTool(BaseTool):
 
     @staticmethod
     def is_safe_command(command_str: str) -> bool:
-        """判断一个 git 命令是否安全（只读，不需要审核）。
+        """判断一个 git 命令是否安全(只读,不需要审核).
 
         Args:
             command_str: 完整的 git 命令字符串
 
         Returns:
-            如果是安全命令返回 True，否则返回 False
+            如果是安全命令返回 True,否则返回 False
         """
         if not command_str or not command_str.strip():
             return False

--- a/src/workspace/tools/git_tool.py
+++ b/src/workspace/tools/git_tool.py
@@ -1,0 +1,167 @@
+"""统一的 Git 工具 — 白名单机制，安全封装."""
+
+import re
+import shlex
+import subprocess
+
+from src.models.tool_error_response import ToolErrorResponse
+from src.workspace.tools.base_tool import BaseTool
+from src.workspace.workspace import Workspace
+
+# 安全命令（只读，直接执行，不需要审核）
+_SAFE_COMMANDS = frozenset({"status", "diff", "log", "show"})
+
+# 白名单（所有允许的命令）
+_ALLOWED_COMMANDS = frozenset(
+    {
+        "status",
+        "diff",
+        "log",
+        "add",
+        "commit",
+        "restore",
+        "show",
+        "branch",
+    }
+)
+
+# 拦截正则 — 即使白名单允许的也再检查一次
+_BLOCKED_PATTERNS = [
+    re.compile(r"\bpush\b"),
+    re.compile(r"\bremote\b"),
+    re.compile(r"\breset\s+--hard\b"),
+    re.compile(r"\bbranch\s+-D\b"),
+    re.compile(r"\bmerge\b"),
+    re.compile(r"\brebase\b"),
+    re.compile(r"\bclean\b"),
+    re.compile(r"\bcheckout\s+-B\b"),
+    re.compile(r"\bcherry-pick\b"),
+    re.compile(r"\btag\b"),
+    re.compile(r"\bfetch\b"),
+    re.compile(r"\bpull\b"),
+]
+
+
+class GitTool(BaseTool):
+    """统一的 Git 工具 — 安全的子命令执行.
+
+    白名单机制：
+    - 安全命令 (status, diff, log, show): 直接执行，不触发审核
+    - 修改命令 (add, commit, restore, branch): 执行并标记 PENDING_AUDIT
+    - 禁止命令 (push, reset --hard, merge, rebase, ...): 拦截并返回错误
+    """
+
+    def __init__(self, workspace: Workspace):
+        super().__init__(workspace, "git", self.git.__doc__, read_permission=True)
+        self.func = self.git
+        self.params = BaseTool.extract_params(self.git)
+
+    def git(self, command_str: str) -> str:
+        """
+        执行 Git 命令（白名单限制）
+
+        Parameters
+        ----------
+        command_str: Git 子命令及其参数，如 "status"、"diff --cached"、"log --oneline -5"
+        """
+        if not command_str or not command_str.strip():
+            return ToolErrorResponse(self.__class__.__name__, ValueError("command_str 不能为空")).to_str()
+
+        try:
+            tokens = shlex.split(command_str)
+        except ValueError as e:
+            return ToolErrorResponse(self.__class__.__name__, e).to_str()
+
+        if not tokens:
+            return ToolErrorResponse(self.__class__.__name__, ValueError("无法解析命令")).to_str()
+
+        base_command = tokens[0]
+
+        # 1. 白名单检查
+        if base_command not in _ALLOWED_COMMANDS:
+            allowed_list = ", ".join(sorted(_ALLOWED_COMMANDS))
+            return (
+                f"ERROR: Git command '{base_command}' is not in the allowed whitelist.\n"
+                f"Allowed commands: {allowed_list}"
+            )
+
+        # 2. 拦截正则检查
+        for pattern in _BLOCKED_PATTERNS:
+            if pattern.search(command_str):
+                return (
+                    f"ERROR: The command was blocked by security policy.\n"
+                    f"Pattern matched: {pattern.pattern}\n"
+                    f"Command: {command_str}"
+                )
+
+        # 3. restore 安全检查 — 必须指定文件路径
+        if base_command == "restore":
+            non_flag_args = [t for t in tokens[1:] if not t.startswith("-")]
+            if not non_flag_args:
+                return ToolErrorResponse(
+                    self.__class__.__name__,
+                    ValueError("restore 需要指定文件路径，不允许裸 restore"),
+                ).to_str()
+            for arg in non_flag_args:
+                stripped = arg.strip()
+                if stripped in (".", "*", "all") or stripped.startswith("*"):
+                    return ToolErrorResponse(
+                        self.__class__.__name__,
+                        ValueError("restore 需要指定具体文件路径，不允许使用通配符"),
+                    ).to_str()
+
+        # 4. 执行命令
+        try:
+            result = subprocess.run(
+                ["git", *tokens],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=str(self.workspace.root_path),
+            )
+        except FileNotFoundError:
+            return ToolErrorResponse(
+                self.__class__.__name__,
+                OSError("Git 未安装或不在系统 PATH 中"),
+            ).to_str()
+        except subprocess.TimeoutExpired:
+            return ToolErrorResponse(
+                self.__class__.__name__,
+                TimeoutError("Git 命令执行超时（30 秒）"),
+            ).to_str()
+
+        # 5. 处理输出
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            if stderr:
+                return f"Git command failed (exit code {result.returncode}):\n{stderr}"
+            return f"Git command failed (exit code {result.returncode})"
+
+        # Combine stdout and stderr
+        output_parts = []
+        if result.stdout:
+            output_parts.append(result.stdout.rstrip("\n"))
+        if result.stderr:
+            output_parts.append(result.stderr.rstrip("\n"))
+
+        return "\n".join(output_parts) if output_parts else "(no output)"
+
+    @staticmethod
+    def is_safe_command(command_str: str) -> bool:
+        """判断一个 git 命令是否安全（只读，不需要审核）。
+
+        Args:
+            command_str: 完整的 git 命令字符串
+
+        Returns:
+            如果是安全命令返回 True，否则返回 False
+        """
+        if not command_str or not command_str.strip():
+            return False
+        try:
+            tokens = shlex.split(command_str)
+        except ValueError:
+            return False
+        if not tokens:
+            return False
+        return tokens[0] in _SAFE_COMMANDS

--- a/src/workspace/tools/git_tool.py
+++ b/src/workspace/tools/git_tool.py
@@ -112,12 +112,14 @@ class GitTool(BaseTool):
 
         # 4. 执行命令
         try:
+            env = {**__import__("os").environ, "GIT_PAGER": "cat", "GIT_TERMINAL_PROMPT": "0"}
             result = subprocess.run(
                 ["git", *tokens],
                 capture_output=True,
                 text=True,
                 timeout=30,
                 cwd=str(self.workspace.root_path),
+                env=env,
             )
         except FileNotFoundError:
             return ToolErrorResponse(
@@ -132,7 +134,7 @@ class GitTool(BaseTool):
 
         # 5. 处理输出
         if result.returncode != 0:
-            stderr = result.stderr.strip()
+            stderr = (result.stderr or "").strip()
             if stderr:
                 return f"Git command failed (exit code {result.returncode}):\n{stderr}"
             return f"Git command failed (exit code {result.returncode})"
@@ -143,6 +145,28 @@ class GitTool(BaseTool):
             output_parts.append(result.stdout.rstrip("\n"))
         if result.stderr:
             output_parts.append(result.stderr.rstrip("\n"))
+        if result.stdout is None and not result.stderr:
+            # HACK: subprocess.run with capture_output=True returns None for stdout
+            # on this platform. Fallback: re-run with explicit PIPE (bytes mode).
+            # 这是Ruff的`UP022`规则报的lint警告:建议用`capture_output=True`替代显式设置`stdout=PIPE, stderr=PIPE`
+            # 但这里的场景特殊——正是`capture_output=True, text=True`导致stdout为`None`,
+            #   才需要回退到bytes模式的手动PIPE, 所以这是一个**有意为之的例外**,不应遵循该建议.
+            _result2 = subprocess.run(  # noqa: UP022
+                ["git", *tokens],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=30,
+                cwd=str(self.workspace.root_path),
+                env={**__import__("os").environ, "GIT_PAGER": "cat", "GIT_TERMINAL_PROMPT": "0"},
+            )
+            out = _result2.stdout.decode("utf-8", errors="replace") if _result2.stdout else ""
+            err = _result2.stderr.decode("utf-8", errors="replace") if _result2.stderr else ""
+            if out:
+                output_parts.append(out.rstrip("\n"))
+            if err:
+                output_parts.append(err.rstrip("\n"))
+            if not output_parts and _result2.returncode != 0:
+                return f"Git command failed (exit code {_result2.returncode})"
 
         return "\n".join(output_parts) if output_parts else "(no output)"
 

--- a/src/workspace/tools/read_lines_tool.py
+++ b/src/workspace/tools/read_lines_tool.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from src.core.file_tracker import FileTracker
 from src.models.tool_error_response import ToolErrorResponse
 from src.workspace.path_validator import PathNotFoundError, WorkspaceBoundaryError
 from src.workspace.tools.base_tool import BaseTool
@@ -62,6 +63,8 @@ class ReadLinesTool(BaseTool):
             header = f"\n[文件: {path}]\n[行 {start}-{end} / 共 {total_lines} 行]\n"
             separator = "-" * 80 + "\n"
 
+            self._record_read_meta(path)
+
             return header + separator + "\n".join(result_lines)
         except PathNotFoundError as err1:
             return ToolErrorResponse(self.__class__.__name__, err1).to_str()
@@ -71,3 +74,12 @@ class ReadLinesTool(BaseTool):
             return ToolErrorResponse(self.__class__.__name__, err3).to_str()
         except Exception as err:
             return ToolErrorResponse(self.__class__.__name__, err).to_str()
+
+    def _record_read_meta(self, resolved_path: Path) -> None:
+        try:
+            meta = FileTracker.get_file_meta(resolved_path)
+            if meta:
+                rel_path = str(resolved_path.relative_to(self.workspace.root_path))
+                self.workspace.db.record_file_read(rel_path, meta["mtime"], meta["size"], meta["checksum"])
+        except Exception:
+            pass

--- a/src/workspace/tools/read_tool.py
+++ b/src/workspace/tools/read_tool.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from src.core.file_tracker import FileTracker
 from src.models.tool_error_response import ToolErrorResponse
 from src.workspace.path_validator import PathNotFoundError, WorkspaceBoundaryError
 from src.workspace.tools.base_tool import BaseTool
@@ -14,31 +15,41 @@ class ReadTool(BaseTool):
 
     def read(self, file_path: str, max_lines: int = 0, encoding: str = "utf-8") -> str:
         """
-        读取文件全部内容, 若指定max_lines>0,则仅读取前max_lines行, 返回字符串
+        读取文件内容,可限制最大行数,返回文件内容字符串(带行号)
 
         Parameters
         ----------
         file_path: 文件路径
-        max_lines: 从第一行开始的最大行数, 为0时读取全部内容
+        max_lines: 最大行数(0表示不限制)
         encoding: 编码
         """
         try:
             path: Path = self.workspace.path_validator.validate(file_path)
-            content = ToolErrorResponse(self.__class__.__name__, f"读取文件{file_path}时未读取到完整文件").to_str()
+
+            if not path.is_file():
+                return ToolErrorResponse(
+                    self.__class__.__name__, ValueError(f"读取文件{path}时未读取到完整文件")
+                ).to_str()
+
+            with open(path, encoding=encoding) as f:
+                lines = f.readlines()
+
+            total_lines = len(lines)
+
             if max_lines > 0:
-                # 按行读取,只读取前 max_size 行
-                lines = []
-                with open(path, encoding=encoding) as f:
-                    for i, line in enumerate(f):
-                        if i >= max_lines:
-                            break
-                        lines.append(line)
-                content = "".join(lines)
-            else:
-                # 读取整个文件
-                with open(path, encoding=encoding) as f:
-                    content: str = f.read()
-            return content
+                lines = lines[:max_lines]
+
+            result_lines = []
+            for i, line in enumerate(lines, 1):
+                content = line.rstrip("\n\r")
+                result_lines.append(f"{i:6d} | {content}")
+
+            header = f"\n[文件: {path}]\n[行 1-{len(lines)} / 共 {total_lines} 行]\n"
+            separator = "-" * 80 + "\n"
+
+            self._record_read_meta(path)
+
+            return header + separator + "\n".join(result_lines)
         except PathNotFoundError as err1:
             return ToolErrorResponse(self.__class__.__name__, err1).to_str()
         except WorkspaceBoundaryError as err2:
@@ -47,3 +58,12 @@ class ReadTool(BaseTool):
             return ToolErrorResponse(self.__class__.__name__, err3).to_str()
         except Exception as err:
             return ToolErrorResponse(self.__class__.__name__, err).to_str()
+
+    def _record_read_meta(self, resolved_path: Path) -> None:
+        try:
+            meta = FileTracker.get_file_meta(resolved_path)
+            if meta:
+                rel_path = str(resolved_path.relative_to(self.workspace.root_path))
+                self.workspace.db.record_file_read(rel_path, meta["mtime"], meta["size"], meta["checksum"])
+        except Exception:
+            pass

--- a/src/workspace/tools/write_tool.py
+++ b/src/workspace/tools/write_tool.py
@@ -1,5 +1,7 @@
+import difflib
 from pathlib import Path
 
+from src.core.file_tracker import FileTracker
 from src.models.tool_error_response import ToolErrorResponse
 from src.workspace.path_validator import PathNotFoundError, WorkspaceBoundaryError
 from src.workspace.tools.base_tool import BaseTool
@@ -8,27 +10,45 @@ from src.workspace.workspace import Workspace
 
 class WriteTool(BaseTool):
     def __init__(self, workspace: Workspace):
-        super().__init__(workspace, "write", self.write.__doc__, False, True)
+        super().__init__(workspace, "write", self.write.__doc__, write_permission=True)
         self.func = self.write
         self.params = BaseTool.extract_params(self.write)
 
     def write(self, file_path: str, content: str = "") -> str:
         """
-        向文件写入内容, 注意:此操作会[覆盖]原文件内容,用户没有要求的情况下禁止使用
+        写入文件内容,如文件不存在则创建(含父目录)
 
         Parameters
         ----------
-        file_path: 要写入的文件路径
-        content: 写入的文本内容
+        file_path: 文件路径
+        content: 写入内容
         """
         try:
             source_file_path = Path(file_path)
             file_path: Path = self.workspace.path_validator.resolve_path(source_file_path)
+
             if file_path.exists() and file_path.is_dir():
                 return ToolErrorResponse(
-                    self.__class__.__name__, f'"{source_file_path}"不是文件路径, 请检查是否输错了文件夹路径'
+                    self.__class__.__name__, ValueError(f"路径 {file_path} 是一个目录,无法写入")
                 ).to_str()
+
+            mtime_error = self._validate_mtime(file_path)
+            if mtime_error:
+                return mtime_error
+
+            old_content = ""
+            old_meta = None
+            if file_path.exists() and file_path.is_file():
+                old_meta = FileTracker.get_file_meta(file_path)
+                try:
+                    old_content = file_path.read_text(encoding="utf-8")
+                except Exception:
+                    old_content = ""
+
             self.workspace.path_validator.create_file_with_parents(file_path, content)
+
+            self._record_write_snapshot(file_path, old_meta, old_content, content)
+
             return "write success"
         except PathNotFoundError as err1:
             return ToolErrorResponse(self.__class__.__name__, err1).to_str()
@@ -38,3 +58,50 @@ class WriteTool(BaseTool):
             return ToolErrorResponse(self.__class__.__name__, err3).to_str()
         except Exception as err:
             return ToolErrorResponse(self.__class__.__name__, err).to_str()
+
+    def _validate_mtime(self, resolved_path: Path) -> str | None:
+        if not resolved_path.exists():
+            return None
+
+        rel_path = str(resolved_path.relative_to(self.workspace.root_path))
+        record = self.workspace.db.get_file_read_record(rel_path)
+        if record is None:
+            return None
+
+        stored_mtime = record[2]
+        current_mtime = resolved_path.stat().st_mtime
+
+        if abs(current_mtime - stored_mtime) > 0.001:
+            return (
+                f'ERROR: FILE_MODIFIED_EXTERNALLY - '
+                f'The file "{rel_path}" was modified externally since last read. '
+                f'Please re-read the file with the "read" tool before writing to it.'
+            )
+        return None
+
+    def _record_write_snapshot(
+        self, resolved_path: Path, old_meta: dict | None, old_content: str, new_content: str
+    ) -> None:
+        try:
+            rel_path = str(resolved_path.relative_to(self.workspace.root_path))
+            old_hash = old_meta.get("checksum") if old_meta else None
+            new_hash = FileTracker.compute_checksum_from_string(new_content)
+            diff_content = self._generate_diff(old_content, new_content, rel_path)
+
+            session_id = self.workspace._current_session_id
+            self.workspace.db.record_file_snapshot(
+                rel_path, old_hash, new_hash, diff_content, audit_status="PENDING_AUDIT", session_id=session_id
+            )
+
+            new_meta = FileTracker.get_file_meta(resolved_path)
+            if new_meta:
+                self.workspace.db.record_file_read(rel_path, new_meta["mtime"], new_meta["size"], new_meta["checksum"])
+        except Exception:
+            pass
+
+    @staticmethod
+    def _generate_diff(old_content: str, new_content: str, file_path: str) -> str:
+        old_lines = old_content.splitlines(keepends=True)
+        new_lines = new_content.splitlines(keepends=True)
+        diff = difflib.unified_diff(old_lines, new_lines, fromfile=f"a/{file_path}", tofile=f"b/{file_path}")
+        return "".join(diff)

--- a/src/workspace/tools/write_tool.py
+++ b/src/workspace/tools/write_tool.py
@@ -45,11 +45,23 @@ class WriteTool(BaseTool):
                 except Exception:
                     old_content = ""
 
-            self.workspace.path_validator.create_file_with_parents(file_path, content)
+            rel_path = str(file_path.relative_to(self.workspace.root_path))
+            old_hash = old_meta.get("checksum") if old_meta else None
+            new_hash = FileTracker.compute_checksum_from_string(content)
+            diff_content = self._generate_diff(old_content, content, rel_path)
 
-            self._record_write_snapshot(file_path, old_meta, old_content, content)
+            session_id = self.workspace._current_session_id
+            snapshot_id = self.workspace.db.record_file_snapshot(
+                rel_path,
+                old_hash,
+                new_hash,
+                diff_content,
+                audit_status="PENDING_AUDIT",
+                session_id=session_id,
+                pending_content=content,
+            )
 
-            return "write success"
+            return f"[Write Preview]\nFile: {rel_path}\nSnapshot ID: {snapshot_id}\nDiff:\n{diff_content}"
         except PathNotFoundError as err1:
             return ToolErrorResponse(self.__class__.__name__, err1).to_str()
         except WorkspaceBoundaryError as err2:
@@ -73,31 +85,11 @@ class WriteTool(BaseTool):
 
         if abs(current_mtime - stored_mtime) > 0.001:
             return (
-                f'ERROR: FILE_MODIFIED_EXTERNALLY - '
+                f"ERROR: FILE_MODIFIED_EXTERNALLY - "
                 f'The file "{rel_path}" was modified externally since last read. '
                 f'Please re-read the file with the "read" tool before writing to it.'
             )
         return None
-
-    def _record_write_snapshot(
-        self, resolved_path: Path, old_meta: dict | None, old_content: str, new_content: str
-    ) -> None:
-        try:
-            rel_path = str(resolved_path.relative_to(self.workspace.root_path))
-            old_hash = old_meta.get("checksum") if old_meta else None
-            new_hash = FileTracker.compute_checksum_from_string(new_content)
-            diff_content = self._generate_diff(old_content, new_content, rel_path)
-
-            session_id = self.workspace._current_session_id
-            self.workspace.db.record_file_snapshot(
-                rel_path, old_hash, new_hash, diff_content, audit_status="PENDING_AUDIT", session_id=session_id
-            )
-
-            new_meta = FileTracker.get_file_meta(resolved_path)
-            if new_meta:
-                self.workspace.db.record_file_read(rel_path, new_meta["mtime"], new_meta["size"], new_meta["checksum"])
-        except Exception:
-            pass
 
     @staticmethod
     def _generate_diff(old_content: str, new_content: str, file_path: str) -> str:

--- a/src/workspace/workspace.py
+++ b/src/workspace/workspace.py
@@ -36,15 +36,28 @@ class Workspace:
     def __new__(cls, path: str):
         if not cls._instance:
             cls._instance = super().__new__(cls)
-            cls._instance.__init__(path)
+            cls._instance._initialized = False
         return cls._instance
 
     def __init__(self, path: str):
+        if self._initialized:
+            return
         self.root_path = Path(path).resolve()
         self.path_validator: PathValidator = PathValidator(self.root_path)
         self.is_git_repo: bool = (self.root_path / ".git").is_dir()
         self.platform: str = sys.platform
         self.date: str = date.today().strftime("%y-%m-%d")
+        self._db = None
+        self._current_session_id: int | None = None
+        self._initialized = True
+
+    @property
+    def db(self):
+        if self._db is None:
+            from src.core.database_manager import DatabaseManager
+
+            self._db = DatabaseManager(str(self.root_path))
+        return self._db
 
     def search_content(
         self,

--- a/tests/core/test_audit_committer.py
+++ b/tests/core/test_audit_committer.py
@@ -1,0 +1,144 @@
+import time
+from pathlib import Path
+
+import pytest
+
+from src.core.audit_committer import AuditCommitter
+from src.core.database_manager import DatabaseManager
+from src.workspace.workspace import Workspace
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+    yield
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    ws = Workspace(str(tmp_path))
+    return ws
+
+
+@pytest.fixture
+def committer(workspace: Workspace) -> AuditCommitter:
+    return AuditCommitter(workspace)
+
+
+def _create_pending_snapshot(workspace: Workspace, file_path: str, pending_content: str) -> int:
+    """Helper to create a PENDING_AUDIT snapshot."""
+    return workspace.db.record_file_snapshot(
+        file_path,
+        "old_hash",
+        "new_hash",
+        "diff_content",
+        audit_status="PENDING_AUDIT",
+        pending_content=pending_content,
+    )
+
+
+class TestCommitNewFile:
+    def test_approve_creates_new_file(self, committer: AuditCommitter, workspace: Workspace):
+        snapshot_id = _create_pending_snapshot(workspace, "new_file.txt", "hello world")
+        result = committer.commit(snapshot_id, approved=True)
+
+        assert "已批准" in result
+        target = workspace.root_path / "new_file.txt"
+        assert target.is_file()
+        assert target.read_text(encoding="utf-8") == "hello world"
+
+    def test_approve_updates_audit_status(self, committer: AuditCommitter, workspace: Workspace):
+        snapshot_id = _create_pending_snapshot(workspace, "new_file.txt", "content")
+        committer.commit(snapshot_id, approved=True)
+
+        snap = workspace.db.get_snapshot_by_id(snapshot_id)
+        assert snap is not None
+        assert snap[7] == "APPROVED"
+
+    def test_approve_creates_file_in_subdir(self, committer: AuditCommitter, workspace: Workspace):
+        snapshot_id = _create_pending_snapshot(workspace, "sub/dir/new_file.txt", "nested")
+        committer.commit(snapshot_id, approved=True)
+
+        target = workspace.root_path / "sub" / "dir" / "new_file.txt"
+        assert target.is_file()
+        assert target.read_text(encoding="utf-8") == "nested"
+
+
+class TestCommitExistingFile:
+    def test_approve_existing_file_with_read(self, committer: AuditCommitter, workspace: Workspace):
+        target = workspace.root_path / "test.txt"
+        target.write_text("original", encoding="utf-8")
+
+        workspace.db.record_file_read("test.txt", target.stat().st_mtime, target.stat().st_size, "hash")
+
+        snapshot_id = _create_pending_snapshot(workspace, "test.txt", "updated content")
+        result = committer.commit(snapshot_id, approved=True)
+
+        assert "已批准" in result
+        assert target.read_text(encoding="utf-8") == "updated content"
+
+    def test_approve_existing_file_no_read_record(self, committer: AuditCommitter, workspace: Workspace):
+        target = workspace.root_path / "test.txt"
+        target.write_text("original", encoding="utf-8")
+
+        snapshot_id = _create_pending_snapshot(workspace, "test.txt", "updated content")
+        result = committer.commit(snapshot_id, approved=True)
+
+        assert "已批准" in result
+        assert target.read_text(encoding="utf-8") == "updated content"
+
+    def test_approve_mtime_mismatch_fails(self, committer: AuditCommitter, workspace: Workspace):
+        target = workspace.root_path / "test.txt"
+        target.write_text("original", encoding="utf-8")
+
+        workspace.db.record_file_read("test.txt", target.stat().st_mtime, target.stat().st_size, "hash")
+
+        # Modify file externally
+        time.sleep(0.1)
+        target.write_text("modified externally", encoding="utf-8")
+
+        snapshot_id = _create_pending_snapshot(workspace, "test.txt", "should fail")
+        result = committer.commit(snapshot_id, approved=True)
+
+        assert "ERROR" in result or "已被外部修改" in result
+        assert target.read_text(encoding="utf-8") == "modified externally"
+
+
+class TestCommitReject:
+    def test_reject_does_not_write(self, committer: AuditCommitter, workspace: Workspace):
+        snapshot_id = _create_pending_snapshot(workspace, "should_not_exist.txt", "content")
+        result = committer.commit(snapshot_id, approved=False)
+
+        assert "已拒绝" in result
+        assert not (workspace.root_path / "should_not_exist.txt").is_file()
+
+    def test_reject_updates_status(self, committer: AuditCommitter, workspace: Workspace):
+        snapshot_id = _create_pending_snapshot(workspace, "test.txt", "content")
+        committer.commit(snapshot_id, approved=False)
+
+        snap = workspace.db.get_snapshot_by_id(snapshot_id)
+        assert snap is not None
+        assert snap[7] == "REJECTED"
+
+
+class TestCommitEdgeCases:
+    def test_commit_nonexistent_snapshot(self, committer: AuditCommitter):
+        result = committer.commit(9999, approved=True)
+        assert "不存在" in result
+
+    def test_commit_already_approved(self, committer: AuditCommitter, workspace: Workspace):
+        snapshot_id = _create_pending_snapshot(workspace, "test.txt", "content")
+        committer.commit(snapshot_id, approved=True)
+
+        result = committer.commit(snapshot_id, approved=True)
+        assert "已处理" in result
+
+    def test_commit_already_rejected(self, committer: AuditCommitter, workspace: Workspace):
+        snapshot_id = _create_pending_snapshot(workspace, "test.txt", "content")
+        committer.commit(snapshot_id, approved=False)
+
+        result = committer.commit(snapshot_id, approved=False)
+        assert "已处理" in result

--- a/tests/core/test_database_manager.py
+++ b/tests/core/test_database_manager.py
@@ -1,0 +1,237 @@
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from src.core.database_manager import DatabaseManager
+
+
+@pytest.fixture(autouse=True)
+def isolate_database_manager():
+    DatabaseManager.reset_instances()
+    yield
+    DatabaseManager.reset_instances()
+
+
+@pytest.fixture
+def workspace_root(tmp_path: Path) -> str:
+    return str(tmp_path / "workspace")
+
+
+@pytest.fixture
+def db(workspace_root: str) -> DatabaseManager:
+    root = Path(workspace_root)
+    root.mkdir(parents=True, exist_ok=True)
+    return DatabaseManager(workspace_root)
+
+
+class TestSingleton:
+    def test_same_path_returns_same_instance(self, workspace_root: str):
+        root = Path(workspace_root)
+        root.mkdir(parents=True, exist_ok=True)
+        db1 = DatabaseManager(workspace_root)
+        db2 = DatabaseManager(workspace_root)
+        assert db1 is db2
+
+    def test_different_paths_return_different_instances(self, tmp_path: Path):
+        root1 = tmp_path / "ws1"
+        root2 = tmp_path / "ws2"
+        root1.mkdir()
+        root2.mkdir()
+        db1 = DatabaseManager(str(root1))
+        db2 = DatabaseManager(str(root2))
+        assert db1 is not db2
+
+
+class TestDirectoryAndDbCreation:
+    def test_directory_created_on_init(self, db: DatabaseManager, workspace_root: str):
+        assert (Path(workspace_root) / ".ManualAid").is_dir()
+
+    def test_db_file_exists_after_init(self, db: DatabaseManager):
+        assert db.db_path.is_file()
+
+    def test_wal_mode_enabled(self, db: DatabaseManager):
+        row = db.fetchone("PRAGMA journal_mode")
+        assert row is not None
+        assert row[0] == "wal"
+
+
+class TestTableCreation:
+    def test_sessions_table_exists(self, db: DatabaseManager):
+        rows = db.fetchall("SELECT name FROM sqlite_master WHERE type='table' AND name='sessions'")
+        assert len(rows) == 1
+
+    def test_tool_calls_table_exists(self, db: DatabaseManager):
+        rows = db.fetchall("SELECT name FROM sqlite_master WHERE type='table' AND name='tool_calls'")
+        assert len(rows) == 1
+
+    def test_file_read_records_table_exists(self, db: DatabaseManager):
+        rows = db.fetchall("SELECT name FROM sqlite_master WHERE type='table' AND name='file_read_records'")
+        assert len(rows) == 1
+
+    def test_file_snapshots_table_exists(self, db: DatabaseManager):
+        rows = db.fetchall("SELECT name FROM sqlite_master WHERE type='table' AND name='file_snapshots'")
+        assert len(rows) == 1
+
+
+class TestSessionLifecycle:
+    def test_create_session(self, db: DatabaseManager):
+        session_id = db.create_session(name="test_session")
+        assert isinstance(session_id, int)
+        assert session_id > 0
+
+    def test_close_session_updates_duration(self, db: DatabaseManager):
+        session_id = db.create_session(name="test_session")
+        time.sleep(0.05)
+        db.close_session(session_id)
+
+        row = db.fetchone("SELECT duration FROM sessions WHERE id = ?", (session_id,))
+        assert row is not None
+        assert row[0] > 0
+
+    def test_close_nonexistent_session(self, db: DatabaseManager):
+        db.close_session(9999)
+
+
+class TestToolCallLogging:
+    def test_log_tool_call(self, db: DatabaseManager):
+        session_id = db.create_session()
+        call_id = db.log_tool_call(session_id, "read", "abc123", duration_ms=50.0, status="success")
+        assert isinstance(call_id, int)
+        assert call_id > 0
+
+    def test_log_tool_call_stored_correctly(self, db: DatabaseManager):
+        session_id = db.create_session()
+        db.log_tool_call(session_id, "write", "def456", duration_ms=120.0, status="error", audit_status="none")
+
+        row = db.fetchone(
+            "SELECT func_name, args_hash, duration_ms, status FROM tool_calls WHERE session_id = ?",
+            (session_id,),
+        )
+        assert row is not None
+        assert row[0] == "write"
+        assert row[1] == "def456"
+        assert row[2] == 120.0
+        assert row[3] == "error"
+
+    def test_update_tool_call_status(self, db: DatabaseManager):
+        session_id = db.create_session()
+        call_id = db.log_tool_call(session_id, "edit", "xyz")
+
+        db.update_tool_call_status(call_id, "error", "PENDING_AUDIT")
+
+        row = db.fetchone("SELECT status, audit_status FROM tool_calls WHERE id = ?", (call_id,))
+        assert row is not None
+        assert row[0] == "error"
+        assert row[1] == "PENDING_AUDIT"
+
+
+class TestFileReadRecords:
+    def test_record_file_read(self, db: DatabaseManager):
+        db.record_file_read("src/main.py", 1234567890.5, 1024, "abc123hash")
+
+        row = db.get_file_read_record("src/main.py")
+        assert row is not None
+        assert row[2] == 1234567890.5
+        assert row[3] == 1024
+        assert row[4] == "abc123hash"
+
+    def test_record_file_read_upsert(self, db: DatabaseManager):
+        db.record_file_read("src/main.py", 1000.0, 100, "hash1")
+        db.record_file_read("src/main.py", 2000.0, 200, "hash2")
+
+        row = db.get_file_read_record("src/main.py")
+        assert row is not None
+        assert row[2] == 2000.0
+        assert row[3] == 200
+        assert row[4] == "hash2"
+        assert row[6] == 2
+
+    def test_get_nonexistent_read_record(self, db: DatabaseManager):
+        row = db.get_file_read_record("nonexistent.py")
+        assert row is None
+
+
+class TestFileSnapshots:
+    def test_record_file_snapshot(self, db: DatabaseManager):
+        snapshot_id = db.record_file_snapshot(
+            "src/main.py", "old_hash", "new_hash", "--- a/src/main.py\n+++ b/src/main.py\n"
+        )
+        assert isinstance(snapshot_id, int)
+        assert snapshot_id > 0
+
+    def test_snapshot_stored_correctly(self, db: DatabaseManager):
+        session_id = db.create_session()
+        db.record_file_snapshot(
+            "src/main.py", None, "new_hash", "diff content", audit_status="PENDING_AUDIT", session_id=session_id
+        )
+
+        rows = db.fetchall("SELECT file_path, old_hash, new_hash, diff_content, audit_status FROM file_snapshots")
+        assert len(rows) == 1
+        assert rows[0][0] == "src/main.py"
+        assert rows[0][1] is None
+        assert rows[0][2] == "new_hash"
+        assert rows[0][3] == "diff content"
+        assert rows[0][4] == "PENDING_AUDIT"
+
+    def test_update_snapshot_audit(self, db: DatabaseManager):
+        snapshot_id = db.record_file_snapshot("src/main.py", "old", "new", "diff")
+
+        db.update_snapshot_audit(snapshot_id, "APPROVED")
+
+        row = db.fetchone("SELECT audit_status FROM file_snapshots WHERE id = ?", (snapshot_id,))
+        assert row is not None
+        assert row[0] == "APPROVED"
+
+    def test_get_pending_audits(self, db: DatabaseManager):
+        db.record_file_snapshot("a.py", None, "h1", "diff1")
+        db.record_file_snapshot("b.py", "h0", "h2", "diff2")
+        db.record_file_snapshot("c.py", "h0", "h3", "diff3", audit_status="APPROVED")
+
+        pending = db.get_pending_audits()
+        assert len(pending) == 2
+
+    def test_snapshot_with_session_id(self, db: DatabaseManager):
+        session_id = db.create_session()
+        db.record_file_snapshot("src/main.py", "old", "new", "diff", session_id=session_id)
+
+        row = db.fetchone("SELECT session_id FROM file_snapshots WHERE file_path = 'src/main.py'")
+        assert row is not None
+        assert row[0] == session_id
+
+
+class TestThreadSafety:
+    def test_concurrent_writes(self, db: DatabaseManager):
+        import threading
+
+        errors = []
+
+        def write_session(name):
+            try:
+                db.create_session(name=name)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=write_session, args=(f"thread_{i}",)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        rows = db.fetchall("SELECT COUNT(*) FROM sessions")
+        assert rows[0][0] == 5
+
+
+class TestClose:
+    def test_close_and_reopen(self, workspace_root: str):
+        root = Path(workspace_root)
+        root.mkdir(parents=True, exist_ok=True)
+        db1 = DatabaseManager(workspace_root)
+        db1.create_session("first")
+        db1.close()
+
+        db2 = DatabaseManager(workspace_root)
+        rows = db2.fetchall("SELECT COUNT(*) FROM sessions")
+        assert rows[0][0] == 1

--- a/tests/core/test_database_manager.py
+++ b/tests/core/test_database_manager.py
@@ -320,3 +320,183 @@ class TestClose:
         db2 = DatabaseManager(workspace_root)
         rows = db2.fetchall("SELECT COUNT(*) FROM sessions")
         assert rows[0][0] == 1
+
+
+class TestSessionSummary:
+    def test_summary_returns_empty_for_nonexistent_session(self, db: DatabaseManager):
+        summary = db.get_session_summary(9999)
+        assert summary == {}
+
+    def test_summary_with_no_tool_calls(self, db: DatabaseManager):
+        session_id = db.create_session(name="empty_session")
+        summary = db.get_session_summary(session_id)
+        assert summary["name"] == "empty_session"
+        assert summary["total_calls"] == 0
+        assert summary["success_count"] == 0
+        assert summary["fail_count"] == 0
+        assert summary["success_rate"] == 0.0
+
+    def test_summary_with_tool_calls(self, db: DatabaseManager):
+        session_id = db.create_session(name="test")
+        db.log_tool_call(session_id, "read", "hash1", status="success")
+        db.log_tool_call(session_id, "write", "hash2", status="success")
+        db.log_tool_call(session_id, "edit", "hash3", status="error")
+
+        summary = db.get_session_summary(session_id)
+        assert summary["total_calls"] == 3
+        assert summary["success_count"] == 2
+        assert summary["fail_count"] == 1
+        assert summary["success_rate"] == pytest.approx(66.6667, rel=0.01)
+
+    def test_summary_duration(self, db: DatabaseManager):
+        session_id = db.create_session(name="dur_test")
+        time.sleep(0.05)
+        db.close_session(session_id)
+        summary = db.get_session_summary(session_id)
+        assert summary["duration"] > 0
+
+
+class TestAllSessions:
+    def test_get_all_sessions_empty(self, db: DatabaseManager):
+        sessions = db.get_all_sessions()
+        assert len(sessions) == 0
+
+    def test_get_all_sessions_ordering(self, db: DatabaseManager):
+        id1 = db.create_session(name="first")
+        id2 = db.create_session(name="second")
+        id3 = db.create_session(name="third")
+
+        sessions = db.get_all_sessions()
+        assert len(sessions) == 3
+        # Most recent first
+        assert sessions[0][0] == id3
+        assert sessions[1][0] == id2
+        assert sessions[2][0] == id1
+
+    def test_get_all_sessions_returns_columns(self, db: DatabaseManager):
+        db.create_session(name="check_columns")
+        sessions = db.get_all_sessions()
+        row = sessions[0]
+        assert len(row) == 4  # id, name, created_at, duration
+
+
+class TestRenameSession:
+    def test_rename_session(self, db: DatabaseManager):
+        session_id = db.create_session(name="original")
+        db.rename_session(session_id, "renamed")
+        row = db.fetchone("SELECT name FROM sessions WHERE id = ?", (session_id,))
+        assert row is not None
+        assert row[0] == "renamed"
+
+    def test_rename_nonexistent_session(self, db: DatabaseManager):
+        db.rename_session(9999, "ghost")  # Should not raise
+
+
+class TestDeleteSession:
+    def test_delete_session_removes_session(self, db: DatabaseManager):
+        session_id = db.create_session(name="to_delete")
+        db.delete_session(session_id)
+        row = db.fetchone("SELECT id FROM sessions WHERE id = ?", (session_id,))
+        assert row is None
+
+    def test_delete_session_removes_tool_calls(self, db: DatabaseManager):
+        session_id = db.create_session()
+        db.log_tool_call(session_id, "read", "hash1")
+        db.log_tool_call(session_id, "write", "hash2")
+
+        # Verify tool calls exist
+        rows = db.fetchall("SELECT COUNT(*) FROM tool_calls WHERE session_id = ?", (session_id,))
+        assert rows[0][0] == 2
+
+        db.delete_session(session_id)
+
+        rows = db.fetchall("SELECT COUNT(*) FROM tool_calls WHERE session_id = ?", (session_id,))
+        assert rows[0][0] == 0
+
+    def test_delete_session_removes_snapshots(self, db: DatabaseManager):
+        session_id = db.create_session()
+        db.record_file_snapshot("a.py", "old", "new", "diff", session_id=session_id)
+
+        rows = db.fetchall("SELECT COUNT(*) FROM file_snapshots WHERE session_id = ?", (session_id,))
+        assert rows[0][0] == 1
+
+        db.delete_session(session_id)
+
+        rows = db.fetchall("SELECT COUNT(*) FROM file_snapshots WHERE session_id = ?", (session_id,))
+        assert rows[0][0] == 0
+
+    def test_delete_nonexistent_session(self, db: DatabaseManager):
+        db.delete_session(9999)  # Should not raise
+
+    def test_delete_session_keeps_other_sessions(self, db: DatabaseManager):
+        sid1 = db.create_session()
+        sid2 = db.create_session()
+        db.log_tool_call(sid1, "read", "h1")
+        db.log_tool_call(sid2, "write", "h2")
+
+        db.delete_session(sid1)
+
+        remaining = db.fetchall("SELECT id FROM sessions")
+        assert len(remaining) == 1
+        assert remaining[0][0] == sid2
+
+
+class TestToolUsageRanking:
+    def test_ranking_empty(self, db: DatabaseManager):
+        ranking = db.get_tool_usage_ranking()
+        assert len(ranking) == 0
+
+    def test_ranking_global(self, db: DatabaseManager):
+        sid1 = db.create_session()
+        sid2 = db.create_session()
+
+        # Session 1: 3 reads, 2 writes
+        for _ in range(3):
+            db.log_tool_call(sid1, "read", "h", duration_ms=10.0)
+        for _ in range(2):
+            db.log_tool_call(sid1, "write", "h", duration_ms=20.0)
+
+        # Session 2: 1 read, 1 glob
+        db.log_tool_call(sid2, "read", "h", duration_ms=5.0)
+        db.log_tool_call(sid2, "glob", "h", duration_ms=15.0)
+
+        ranking = db.get_tool_usage_ranking(limit=10)
+        assert len(ranking) == 3
+        # read=4, write=2, glob=1
+        assert ranking[0][0] == "read"
+        assert ranking[0][1] == 4
+        assert ranking[1][0] == "write"
+        assert ranking[1][1] == 2
+        assert ranking[2][0] == "glob"
+        assert ranking[2][1] == 1
+
+    def test_ranking_per_session(self, db: DatabaseManager):
+        sid = db.create_session()
+        db.log_tool_call(sid, "read", "h", duration_ms=5.0)
+        db.log_tool_call(sid, "read", "h", duration_ms=10.0)
+        db.log_tool_call(sid, "glob", "h", duration_ms=15.0)
+
+        ranking = db.get_tool_usage_ranking(session_id=sid)
+        assert len(ranking) == 2
+        assert ranking[0][0] == "read"
+        assert ranking[0][1] == 2
+        assert ranking[1][0] == "glob"
+        assert ranking[1][1] == 1
+
+    def test_ranking_avg_duration(self, db: DatabaseManager):
+        sid = db.create_session()
+        db.log_tool_call(sid, "read", "h", duration_ms=10.0)
+        db.log_tool_call(sid, "read", "h", duration_ms=30.0)
+
+        ranking = db.get_tool_usage_ranking(session_id=sid)
+        assert len(ranking) == 1
+        assert ranking[0][0] == "read"
+        assert ranking[0][1] == 2
+        assert ranking[0][2] == pytest.approx(20.0)
+
+    def test_ranking_limit(self, db: DatabaseManager):
+        sid = db.create_session()
+        for tool in ["a", "b", "c", "d", "e"]:
+            db.log_tool_call(sid, tool, "h")
+        ranking = db.get_tool_usage_ranking(session_id=sid, limit=3)
+        assert len(ranking) == 3

--- a/tests/core/test_database_manager.py
+++ b/tests/core/test_database_manager.py
@@ -1,4 +1,3 @@
-import sqlite3
 import time
 from pathlib import Path
 
@@ -199,6 +198,92 @@ class TestFileSnapshots:
         row = db.fetchone("SELECT session_id FROM file_snapshots WHERE file_path = 'src/main.py'")
         assert row is not None
         assert row[0] == session_id
+
+
+class TestPendingContentMigration:
+    def test_pending_content_column_exists(self, db: DatabaseManager):
+        cols = db.fetchall("PRAGMA table_info(file_snapshots)")
+        col_names = [c[1] for c in cols]
+        assert "pending_content" in col_names
+
+    def test_pending_content_default_empty(self, db: DatabaseManager):
+        snapshot_id = db.record_file_snapshot("src/main.py", "old", "new", "diff")
+        row = db.fetchone("SELECT pending_content FROM file_snapshots WHERE id = ?", (snapshot_id,))
+        assert row is not None
+        assert row[0] == ""
+
+    def test_pending_content_stored(self, db: DatabaseManager):
+        session_id = db.create_session()
+        db.execute(
+            "UPDATE file_snapshots SET pending_content = ? WHERE id = ?",
+            ("new file content", 1),
+        )
+        # Use record_file_snapshot with explicit pending_content via direct SQL
+        # since the method currently doesn't have pending_content param
+        snapshot_id = db.record_file_snapshot(
+            "src/main.py",
+            "old_hash",
+            "new_hash",
+            "diff_content",
+            audit_status="PENDING_AUDIT",
+            session_id=session_id,
+        )
+        db.execute(
+            "UPDATE file_snapshots SET pending_content = ? WHERE id = ?",
+            ("pending content here", snapshot_id),
+        )
+        row = db.fetchone("SELECT pending_content FROM file_snapshots WHERE id = ?", (snapshot_id,))
+        assert row is not None
+        assert row[0] == "pending content here"
+
+
+class TestGetSnapshotById:
+    def test_get_existing_snapshot(self, db: DatabaseManager):
+        session_id = db.create_session()
+        db.record_file_snapshot(
+            "src/main.py",
+            "old_hash",
+            "new_hash",
+            "diff_content",
+            audit_status="PENDING_AUDIT",
+            session_id=session_id,
+        )
+        # Set pending_content directly
+        db.execute(
+            "UPDATE file_snapshots SET pending_content = ? WHERE id = ?",
+            ("pending content", 1),
+        )
+
+        row = db.get_snapshot_by_id(1)
+        assert row is not None
+        assert row[1] == "src/main.py"
+        assert row[8] == "pending content"
+
+    def test_get_nonexistent_snapshot(self, db: DatabaseManager):
+        row = db.get_snapshot_by_id(9999)
+        assert row is None
+
+
+class TestGetSnapshotsByAuditStatus:
+    def test_filter_by_status(self, db: DatabaseManager):
+        db.record_file_snapshot("a.py", None, "h1", "diff1")
+        db.record_file_snapshot("b.py", "h0", "h2", "diff2", audit_status="APPROVED")
+        db.record_file_snapshot("c.py", "h0", "h3", "diff3", audit_status="REJECTED")
+
+        pending = db.get_snapshots_by_audit_status("PENDING_AUDIT")
+        approved = db.get_snapshots_by_audit_status("APPROVED")
+        rejected = db.get_snapshots_by_audit_status("REJECTED")
+
+        assert len(pending) == 1
+        assert pending[0][1] == "a.py"
+        assert len(approved) == 1
+        assert approved[0][1] == "b.py"
+        assert len(rejected) == 1
+        assert rejected[0][1] == "c.py"
+
+    def test_no_matching_status(self, db: DatabaseManager):
+        rows = db.get_snapshots_by_audit_status("NONEXISTENT_STATUS")
+        assert len(rows) == 0
 
 
 class TestThreadSafety:

--- a/tests/core/test_file_tracker.py
+++ b/tests/core/test_file_tracker.py
@@ -1,0 +1,91 @@
+import hashlib
+import tempfile
+from pathlib import Path
+
+from src.core.file_tracker import FileTracker
+
+
+class TestComputeChecksum:
+    def test_existing_file(self, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        content = "hello world"
+        file.write_text(content, encoding="utf-8")
+
+        result = FileTracker.compute_checksum(file)
+        expected = hashlib.blake2b(content.encode("utf-8")).hexdigest()
+        assert result == expected
+
+    def test_empty_file(self, tmp_path: Path):
+        file = tmp_path / "empty.txt"
+        file.write_text("", encoding="utf-8")
+
+        result = FileTracker.compute_checksum(file)
+        expected = hashlib.blake2b(b"").hexdigest()
+        assert result == expected
+
+    def test_missing_file(self, tmp_path: Path):
+        file = tmp_path / "nonexistent.txt"
+
+        result = FileTracker.compute_checksum(file)
+        assert result == ""
+
+    def test_binary_file(self, tmp_path: Path):
+        file = tmp_path / "binary.bin"
+        content = b"\x00\x01\x02\xff"
+        file.write_bytes(content)
+
+        result = FileTracker.compute_checksum(file)
+        expected = hashlib.blake2b(content).hexdigest()
+        assert result == expected
+
+
+class TestComputeChecksumFromString:
+    def test_known_content(self):
+        content = "test content"
+        result = FileTracker.compute_checksum_from_string(content)
+        expected = hashlib.blake2b(content.encode("utf-8")).hexdigest()
+        assert result == expected
+
+    def test_empty_string(self):
+        result = FileTracker.compute_checksum_from_string("")
+        expected = hashlib.blake2b(b"").hexdigest()
+        assert result == expected
+
+    def test_deterministic(self):
+        content = "deterministic test"
+        result1 = FileTracker.compute_checksum_from_string(content)
+        result2 = FileTracker.compute_checksum_from_string(content)
+        assert result1 == result2
+
+
+class TestGetFileMeta:
+    def test_existing_file(self, tmp_path: Path):
+        file = tmp_path / "meta.txt"
+        content = "metadata test"
+        file.write_text(content, encoding="utf-8")
+
+        meta = FileTracker.get_file_meta(file)
+
+        assert "mtime" in meta
+        assert "size" in meta
+        assert "checksum" in meta
+        assert meta["size"] == len(content.encode("utf-8"))
+        assert meta["checksum"] == hashlib.blake2b(content.encode("utf-8")).hexdigest()
+        assert isinstance(meta["mtime"], float)
+        assert meta["mtime"] > 0
+
+    def test_missing_file(self, tmp_path: Path):
+        file = tmp_path / "nonexistent.txt"
+
+        meta = FileTracker.get_file_meta(file)
+
+        assert meta == {}
+
+    def test_checksum_matches_compute_checksum(self, tmp_path: Path):
+        file = tmp_path / "consistency.txt"
+        file.write_text("consistency check", encoding="utf-8")
+
+        meta = FileTracker.get_file_meta(file)
+        direct = FileTracker.compute_checksum(file)
+
+        assert meta["checksum"] == direct

--- a/tests/core/test_file_tracker.py
+++ b/tests/core/test_file_tracker.py
@@ -1,5 +1,4 @@
 import hashlib
-import tempfile
 from pathlib import Path
 
 from src.core.file_tracker import FileTracker

--- a/tests/core/test_tool_registry.py
+++ b/tests/core/test_tool_registry.py
@@ -135,5 +135,76 @@ def test_no_compress_short_results():
     assert registry._compress_result(short_dict) == short_dict
 
 
+class TestToolCategorization:
+    """测试工具分类逻辑（需要 workspace 注册工具）。"""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, tmp_path):
+        from src.core.database_manager import DatabaseManager
+        from src.workspace.workspace import Workspace
+
+        Workspace._instance = None
+        DatabaseManager.reset_instances()
+        ws = Workspace(str(tmp_path))
+        registry = ToolRegistry()
+        registry.register(ws)
+
+    def test_query_tools_category(self):
+        registry = ToolRegistry()
+        for name in ("glob", "ls", "regex_search", "stat", "read", "read_lines", "symbol_ref"):
+            assert registry._tool_categories.get(name) == "query", f"{name} should be query"
+
+    def test_edit_tools_category(self):
+        registry = ToolRegistry()
+        for name in ("write", "edit"):
+            assert registry._tool_categories.get(name) == "edit", f"{name} should be edit"
+
+    def test_git_tool_category(self):
+        registry = ToolRegistry()
+        assert registry._tool_categories.get("git") == "dangerous"
+
+    def test_all_tools_have_category(self):
+        registry = ToolRegistry()
+        for name in registry._tools:
+            assert name in registry._tool_categories, f"{name} missing category"
+
+    def test_git_dangerous_commands_get_pending_audit(self, tmp_path):
+        from src.core.database_manager import DatabaseManager
+        from src.workspace.workspace import Workspace
+
+        Workspace._instance = None
+        DatabaseManager.reset_instances()
+        ws = Workspace(str(tmp_path))
+        registry = ToolRegistry()
+        registry.register(ws)
+        session_id = ws.db.create_session()
+        registry.set_session_id(session_id)
+
+        # Simulate a dangerous git call
+        registry._log_tool_call("git", {"command_str": "add file.txt"}, 10.0, "success")
+
+        rows = ws.db.fetchall("SELECT func_name, audit_status FROM tool_calls")
+        assert len(rows) == 1
+        assert rows[0][1] == "PENDING_AUDIT"
+
+    def test_git_safe_commands_no_audit(self, tmp_path):
+        from src.core.database_manager import DatabaseManager
+        from src.workspace.workspace import Workspace
+
+        Workspace._instance = None
+        DatabaseManager.reset_instances()
+        ws = Workspace(str(tmp_path))
+        registry = ToolRegistry()
+        registry.register(ws)
+        session_id = ws.db.create_session()
+        registry.set_session_id(session_id)
+
+        registry._log_tool_call("git", {"command_str": "status"}, 10.0, "success")
+
+        rows = ws.db.fetchall("SELECT func_name, audit_status FROM tool_calls")
+        assert len(rows) == 1
+        assert rows[0][1] == "none"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/core/test_tool_registry.py
+++ b/tests/core/test_tool_registry.py
@@ -136,7 +136,7 @@ def test_no_compress_short_results():
 
 
 class TestToolCategorization:
-    """测试工具分类逻辑（需要 workspace 注册工具）。"""
+    """测试工具分类逻辑(需要 workspace 注册工具)."""
 
     @pytest.fixture(autouse=True)
     def setup(self, tmp_path):

--- a/tests/workspace/tools/test_edit_tool.py
+++ b/tests/workspace/tools/test_edit_tool.py
@@ -1,0 +1,202 @@
+"""Edit 工具测试 — 安全的字符串替换编辑工具."""
+
+import time
+from pathlib import Path
+
+import pytest
+
+from src.core.database_manager import DatabaseManager
+from src.workspace.workspace import Workspace
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+    yield
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    ws = Workspace(str(tmp_path))
+    return ws
+
+
+@pytest.fixture
+def edit_tool(workspace: Workspace):
+    from src.workspace.tools.edit_tool import EditTool
+
+    return EditTool(workspace)
+
+
+@pytest.fixture
+def read_tool(workspace: Workspace):
+    from src.workspace.tools.read_tool import ReadTool
+
+    return ReadTool(workspace)
+
+
+def _create_file(workspace: Workspace, path: str, content: str) -> Path:
+    """Create a file in the workspace."""
+    target = workspace.root_path / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    return target
+
+
+class TestEditBasic:
+    def test_simple_replacement(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "hello world")
+        result = edit_tool.edit("test.txt", "world", "there")
+
+        assert "Edit Preview" in result
+        assert "Snapshot ID:" in result
+
+    def test_does_not_write_to_disk(self, edit_tool, workspace):
+        file = _create_file(workspace, "test.txt", "hello world")
+        edit_tool.edit("test.txt", "world", "there")
+
+        assert file.read_text(encoding="utf-8") == "hello world"
+
+    def test_creates_pending_snapshot(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "hello world")
+        edit_tool.edit("test.txt", "world", "there")
+
+        rows = workspace.db.fetchall("SELECT audit_status, pending_content FROM file_snapshots")
+        assert len(rows) == 1
+        assert rows[0][0] == "PENDING_AUDIT"
+        assert rows[0][1] == "hello there"
+
+    def test_diff_in_preview(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "line1\nline2\nline3")
+        result = edit_tool.edit("test.txt", "line2", "modified")
+
+        assert "-line2" in result
+        assert "+modified" in result
+
+    def test_multiple_replacements(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "a a a a a")
+        result = edit_tool.edit("test.txt", "a", "b", max_replacements=3)
+
+        assert "Replacements: 3" in result
+        # Verify pending content has exactly 3 replacements
+        snap = workspace.db.fetchone("SELECT pending_content FROM file_snapshots")
+        assert snap is not None
+        assert snap[0] == "b b b a a"
+
+    def test_no_match_found(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "hello world")
+        result = edit_tool.edit("test.txt", "nonexistent", "replacement")
+
+        assert "No changes made" in result
+        assert "old_string not found" in result
+
+
+class TestEditMaxReplacements:
+    def test_exceeds_max_replacements(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "a a a a a a a a a a a a")  # 12 a's
+        result = edit_tool.edit("test.txt", "a", "b", max_replacements=5)
+
+        assert "Replacements: 5" in result
+
+    def test_max_replacements_default_10(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", " ".join(["a"] * 20))
+        result = edit_tool.edit("test.txt", "a", "b")
+
+        assert "Replacements: 10" in result
+
+    def test_max_replacements_capped_at_100(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "a " * 150)
+        result = edit_tool.edit("test.txt", "a", "b", max_replacements=200)
+
+        assert "Replacements: 100" in result
+
+
+class TestEditContextValidation:
+    def test_context_before_matches(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "prefix target suffix")
+        result = edit_tool.edit("test.txt", "target", "replaced", context_before="prefix ")
+
+        assert "Edit Preview" in result
+
+    def test_context_before_mismatch(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "prefix target suffix")
+        result = edit_tool.edit("test.txt", "target", "replaced", context_before="wrong ")
+
+        assert "context_before" in result
+        assert "mismatch" in result.lower()
+
+    def test_context_after_matches(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "prefix target suffix")
+        result = edit_tool.edit("test.txt", "target", "replaced", context_after=" suffix")
+
+        assert "Edit Preview" in result
+
+    def test_context_after_mismatch(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "prefix target suffix")
+        result = edit_tool.edit("test.txt", "target", "replaced", context_after=" wrong")
+
+        assert "context_after" in result
+        assert "mismatch" in result.lower()
+
+    def test_both_contexts_match(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "before target after")
+        result = edit_tool.edit("test.txt", "target", "replaced", context_before="before ", context_after=" after")
+
+        assert "Edit Preview" in result
+
+    def test_context_with_multiple_matches(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "before X after\nignore\nbefore X after")
+        result = edit_tool.edit(
+            "test.txt", "X", "Y", max_replacements=2, context_before="before ", context_after=" after"
+        )
+
+        assert "Edit Preview" in result
+        assert "Replacements: 2" in result
+
+
+class TestEditMtimeValidation:
+    def test_edit_modified_externally_fails(self, edit_tool, read_tool, workspace):
+        file = _create_file(workspace, "test.txt", "original content")
+        read_tool.read("test.txt")
+
+        # Modify externally
+        time.sleep(0.1)
+        file.write_text("modified externally", encoding="utf-8")
+
+        result = edit_tool.edit("test.txt", "original", "replaced")
+        assert "FILE_MODIFIED_EXTERNALLY" in result
+
+    def test_edit_no_prior_read_succeeds(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "original content")
+        result = edit_tool.edit("test.txt", "original", "updated")
+
+        assert "Edit Preview" in result
+
+
+class TestEditEdgeCases:
+    def test_empty_old_string(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "content")
+        result = edit_tool.edit("test.txt", "", "replacement")
+
+        assert "不能为空" in result or "empty" in result.lower()
+
+    def test_nonexistent_file(self, edit_tool, workspace):
+        result = edit_tool.edit("nonexistent.txt", "old", "new")
+        assert "不存在" in result or "not found" in result.lower() or "exists" in result.lower()
+
+    def test_file_outside_workspace(self, edit_tool, workspace):
+        result = edit_tool.edit("../outside.txt", "old", "new")
+        assert "越界" in result or "boundary" in result.lower() or "outside" in result.lower()
+
+    def test_edit_snapshot_has_old_hash(self, edit_tool, workspace):
+        _create_file(workspace, "test.txt", "original")
+        edit_tool.edit("test.txt", "original", "updated")
+
+        snap = workspace.db.fetchone("SELECT old_hash, new_hash FROM file_snapshots")
+        assert snap is not None
+        assert snap[0] is not None
+        assert snap[1] is not None
+        assert snap[0] != snap[1]

--- a/tests/workspace/tools/test_git_tool.py
+++ b/tests/workspace/tools/test_git_tool.py
@@ -1,0 +1,174 @@
+"""Git 工具测试 — 白名单机制与安全封装."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.core.database_manager import DatabaseManager
+from src.workspace.workspace import Workspace
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+    yield
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """创建一个带有初始提交的 git 仓库。"""
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@test.com"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, capture_output=True)
+    # Initial commit so commands work against a real repo
+    (repo / "README.md").write_text("# Test\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, capture_output=True)
+    return repo
+
+
+@pytest.fixture
+def workspace(git_repo: Path) -> Workspace:
+    ws = Workspace(str(git_repo))
+    return ws
+
+
+@pytest.fixture
+def git_tool(workspace: Workspace):
+    from src.workspace.tools.git_tool import GitTool
+
+    return GitTool(workspace)
+
+
+class TestGitAllowedCommands:
+    def test_status(self, git_tool):
+        result = git_tool.git("status")
+        assert "nothing to commit" in result.lower() or "working tree clean" in result.lower()
+
+    def test_diff(self, git_tool):
+        result = git_tool.git("diff")
+        assert "(no output)" in result or result == "" or result == "(no output)"
+
+    def test_log(self, git_tool):
+        result = git_tool.git("log --oneline -1")
+        assert "initial" in result.lower()
+
+    def test_show(self, git_tool):
+        result = git_tool.git("show --stat")
+        assert "README" in result or "initial" in result.lower()
+
+    def test_add_and_commit(self, git_tool, git_repo: Path):
+        (git_repo / "new_file.txt").write_text("content", encoding="utf-8")
+        add_result = git_tool.git("add new_file.txt")
+        assert "failed" not in add_result.lower()
+
+        commit_result = git_tool.git('commit -m "test commit"')
+        assert "commi" in commit_result.lower() or "file changed" in commit_result.lower()
+
+    def test_branch(self, git_tool):
+        result = git_tool.git("branch")
+        assert "*" in result or "main" in result or "master" in result
+
+    def test_restore_specific_file(self, git_tool, git_repo: Path):
+        (git_repo / "README.md").write_text("modified\n", encoding="utf-8")
+        result = git_tool.git("restore README.md")
+        assert "failed" not in result.lower()
+
+
+class TestGitBlockedCommands:
+    def test_push_blocked(self, git_tool):
+        result = git_tool.git("push")
+        assert "blocked" in result.lower() or "ERROR" in result
+
+    def test_remote_blocked(self, git_tool):
+        result = git_tool.git("remote add origin http://example.com/repo.git")
+        assert "blocked" in result.lower() or "ERROR" in result
+
+    def test_reset_hard_blocked(self, git_tool):
+        result = git_tool.git("reset --hard HEAD")
+        assert "blocked" in result.lower() or "ERROR" in result
+
+    def test_branch_D_blocked(self, git_tool):
+        result = git_tool.git("branch -D test")
+        assert "blocked" in result.lower() or "ERROR" in result
+
+    def test_merge_blocked(self, git_tool):
+        result = git_tool.git("merge test-branch")
+        assert "blocked" in result.lower() or "ERROR" in result
+
+    def test_rebase_blocked(self, git_tool):
+        result = git_tool.git("rebase main")
+        assert "blocked" in result.lower() or "ERROR" in result
+
+    def test_clean_blocked(self, git_tool):
+        result = git_tool.git("clean -fd")
+        assert "blocked" in result.lower() or "ERROR" in result
+
+    def test_fetch_blocked(self, git_tool):
+        result = git_tool.git("fetch origin")
+        assert "blocked" in result.lower() or "ERROR" in result
+
+    def test_pull_blocked(self, git_tool):
+        result = git_tool.git("pull origin main")
+        assert "blocked" in result.lower() or "ERROR" in result
+
+
+class TestGitRestoreSafety:
+    def test_bare_restore_rejected(self, git_tool):
+        result = git_tool.git("restore")
+        assert "需要指定文件路径" in result or "ERROR" in result or "restore" in result.lower()
+
+    def test_restore_dot_rejected(self, git_tool):
+        result = git_tool.git("restore .")
+        assert "通配符" in result or "ERROR" in result or "restore" in result.lower()
+
+
+class TestGitUnknownCommand:
+    def test_unknown_command_rejected(self, git_tool):
+        result = git_tool.git("unknown-command")
+        assert "not in the allowed whitelist" in result.lower() or "ERROR" in result
+
+
+class TestGitIsSafeCommand:
+    def test_safe_commands(self):
+        from src.workspace.tools.git_tool import GitTool
+
+        assert GitTool.is_safe_command("status")
+        assert GitTool.is_safe_command("diff")
+        assert GitTool.is_safe_command("log --oneline -5")
+        assert GitTool.is_safe_command("show HEAD")
+
+    def test_modifying_commands_not_safe(self):
+        from src.workspace.tools.git_tool import GitTool
+
+        assert not GitTool.is_safe_command("add file.txt")
+        assert not GitTool.is_safe_command('commit -m "msg"')
+        assert not GitTool.is_safe_command("restore file.txt")
+
+    def test_blocked_commands_not_safe(self):
+        from src.workspace.tools.git_tool import GitTool
+
+        assert not GitTool.is_safe_command("push")
+        assert not GitTool.is_safe_command("merge main")
+
+    def test_empty_string(self):
+        from src.workspace.tools.git_tool import GitTool
+
+        assert not GitTool.is_safe_command("")
+        assert not GitTool.is_safe_command("   ")
+
+
+class TestGitInjection:
+    def test_command_injection_via_semicolon(self, git_tool):
+        result = git_tool.git("status; echo pwned")
+        assert "blocked" in result.lower() or "ERROR" in result or "not in the allowed whitelist" in result.lower()
+
+    def test_invalid_shell_syntax(self, git_tool):
+        result = git_tool.git("status $(whoami)")
+        assert "failed" not in result.lower() or "error" not in result.lower()

--- a/tests/workspace/tools/test_git_tool.py
+++ b/tests/workspace/tools/test_git_tool.py
@@ -20,7 +20,7 @@ def reset_singletons():
 
 @pytest.fixture
 def git_repo(tmp_path: Path) -> Path:
-    """创建一个带有初始提交的 git 仓库。"""
+    """创建一个带有初始提交的 git 仓库."""
     repo = tmp_path / "repo"
     repo.mkdir(parents=True)
     subprocess.run(["git", "init"], cwd=repo, capture_output=True)

--- a/tests/workspace/tools/test_git_tool.py
+++ b/tests/workspace/tools/test_git_tool.py
@@ -9,6 +9,7 @@ from src.core.database_manager import DatabaseManager
 from src.workspace.workspace import Workspace
 
 
+# noinspection PyTypeChecker
 @pytest.fixture(autouse=True)
 def reset_singletons():
     Workspace._instance = None
@@ -87,14 +88,14 @@ class TestGitBlockedCommands:
         assert "blocked" in result.lower() or "ERROR" in result
 
     def test_remote_blocked(self, git_tool):
-        result = git_tool.git("remote add origin http://example.com/repo.git")
+        result = git_tool.git("remote add origin https://example.com/repo.git")
         assert "blocked" in result.lower() or "ERROR" in result
 
     def test_reset_hard_blocked(self, git_tool):
         result = git_tool.git("reset --hard HEAD")
         assert "blocked" in result.lower() or "ERROR" in result
 
-    def test_branch_D_blocked(self, git_tool):
+    def test_branch_d_blocked(self, git_tool):
         result = git_tool.git("branch -D test")
         assert "blocked" in result.lower() or "ERROR" in result
 

--- a/tests/workspace/tools/test_read_tool.py
+++ b/tests/workspace/tools/test_read_tool.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 
 from src.core.database_manager import DatabaseManager
-from src.core.file_tracker import FileTracker
 from src.workspace.workspace import Workspace
 
 

--- a/tests/workspace/tools/test_read_tool.py
+++ b/tests/workspace/tools/test_read_tool.py
@@ -1,0 +1,93 @@
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from src.core.database_manager import DatabaseManager
+from src.core.file_tracker import FileTracker
+from src.workspace.workspace import Workspace
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+    yield
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    ws = Workspace(str(tmp_path))
+    return ws
+
+
+class TestReadToolMtimeRecording:
+    def test_read_records_mtime(self, workspace: Workspace, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("hello", encoding="utf-8")
+
+        from src.workspace.tools.read_tool import ReadTool
+
+        tool = ReadTool(workspace)
+        result = tool.read("test.txt")
+
+        assert "hello" in result
+        record = workspace.db.get_file_read_record("test.txt")
+        assert record is not None
+        assert record[2] == pytest.approx(file.stat().st_mtime, abs=0.01)
+
+    def test_read_records_checksum(self, workspace: Workspace, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        content = "checksum test"
+        file.write_text(content, encoding="utf-8")
+
+        from src.workspace.tools.read_tool import ReadTool
+
+        tool = ReadTool(workspace)
+        tool.read("test.txt")
+
+        record = workspace.db.get_file_read_record("test.txt")
+        assert record is not None
+        expected_checksum = hashlib.blake2b(content.encode("utf-8")).hexdigest()
+        assert record[4] == expected_checksum
+
+    def test_read_nonexistent_file_no_db_record(self, workspace: Workspace):
+        from src.workspace.tools.read_tool import ReadTool
+
+        tool = ReadTool(workspace)
+        result = tool.read("nonexistent.txt")
+
+        assert "error" in result.lower() or "Error" in result
+        record = workspace.db.get_file_read_record("nonexistent.txt")
+        assert record is None
+
+    def test_read_updates_read_count(self, workspace: Workspace, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("content", encoding="utf-8")
+
+        from src.workspace.tools.read_tool import ReadTool
+
+        tool = ReadTool(workspace)
+        tool.read("test.txt")
+        tool.read("test.txt")
+
+        record = workspace.db.get_file_read_record("test.txt")
+        assert record is not None
+        assert record[6] == 2
+
+
+class TestReadLinesToolMtimeRecording:
+    def test_read_lines_records_mtime(self, workspace: Workspace, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("line1\nline2\nline3", encoding="utf-8")
+
+        from src.workspace.tools.read_lines_tool import ReadLinesTool
+
+        tool = ReadLinesTool(workspace)
+        result = tool.read_lines("test.txt", 1, 2)
+
+        assert "line1" in result
+        record = workspace.db.get_file_read_record("test.txt")
+        assert record is not None

--- a/tests/workspace/tools/test_write_tool.py
+++ b/tests/workspace/tools/test_write_tool.py
@@ -1,0 +1,133 @@
+import hashlib
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from src.core.database_manager import DatabaseManager
+from src.workspace.workspace import Workspace
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+    yield
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    ws = Workspace(str(tmp_path))
+    return ws
+
+
+@pytest.fixture
+def write_tool(workspace: Workspace):
+    from src.workspace.tools.write_tool import WriteTool
+
+    return WriteTool(workspace)
+
+
+@pytest.fixture
+def read_tool(workspace: Workspace):
+    from src.workspace.tools.read_tool import ReadTool
+
+    return ReadTool(workspace)
+
+
+class TestWriteNewFile:
+    def test_write_new_file_no_mtime_check(self, write_tool, tmp_path: Path):
+        result = write_tool.write("new_file.txt", "hello")
+        assert "success" in result.lower()
+
+    def test_write_new_file_creates_snapshot(self, write_tool, tmp_path: Path):
+        write_tool.write("new_file.txt", "hello")
+
+        rows = write_tool.workspace.db.fetchall("SELECT old_hash, new_hash, audit_status FROM file_snapshots")
+        assert len(rows) == 1
+        assert rows[0][0] is None
+        assert rows[0][2] == "PENDING_AUDIT"
+
+
+class TestWriteAfterRead:
+    def test_write_after_read_succeeds(self, write_tool, read_tool, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("original", encoding="utf-8")
+
+        read_tool.read("test.txt")
+        result = write_tool.write("test.txt", "updated")
+        assert "success" in result.lower()
+
+    def test_write_after_read_has_old_hash(self, write_tool, read_tool, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("original", encoding="utf-8")
+
+        read_tool.read("test.txt")
+        write_tool.write("test.txt", "updated")
+
+        rows = write_tool.workspace.db.fetchall("SELECT old_hash, new_hash FROM file_snapshots")
+        assert len(rows) == 1
+        assert rows[0][0] is not None
+        assert rows[0][1] != rows[0][0]
+
+
+class TestWriteModifiedExternally:
+    def test_write_modified_externally_fails(self, write_tool, read_tool, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("original", encoding="utf-8")
+
+        read_tool.read("test.txt")
+
+        file.write_text("modified externally", encoding="utf-8")
+        time.sleep(0.01)
+
+        result = write_tool.write("test.txt", "should fail")
+        assert "FILE_MODIFIED_EXTERNALLY" in result
+
+    def test_write_no_prior_read_succeeds(self, write_tool, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("existing content", encoding="utf-8")
+
+        result = write_tool.write("test.txt", "new content")
+        assert "success" in result.lower()
+
+
+class TestWriteDiffContent:
+    def test_write_diff_content(self, write_tool, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("line1\nline2\nline3", encoding="utf-8")
+
+        from src.workspace.tools.read_tool import ReadTool
+
+        ReadTool(write_tool.workspace).read("test.txt")
+        write_tool.write("test.txt", "line1\nmodified\nline3")
+
+        rows = write_tool.workspace.db.fetchall("SELECT diff_content FROM file_snapshots")
+        assert len(rows) == 1
+        assert "-line2" in rows[0][0]
+        assert "+modified" in rows[0][0]
+
+    def test_write_new_file_no_diff(self, write_tool, tmp_path: Path):
+        write_tool.write("new_file.txt", "brand new")
+
+        rows = write_tool.workspace.db.fetchall("SELECT diff_content FROM file_snapshots")
+        assert len(rows) == 1
+        assert "+brand new" in rows[0][0]
+
+
+class TestWriteUpdatesReadRecord:
+    def test_write_updates_read_record(self, write_tool, read_tool, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("original", encoding="utf-8")
+
+        read_tool.read("test.txt")
+        record_before = write_tool.workspace.db.get_file_read_record("test.txt")
+
+        write_tool.write("test.txt", "updated content")
+        record_after = write_tool.workspace.db.get_file_read_record("test.txt")
+
+        assert record_after is not None
+        assert record_after[4] != record_before[4]

--- a/tests/workspace/tools/test_write_tool.py
+++ b/tests/workspace/tools/test_write_tool.py
@@ -1,5 +1,3 @@
-import hashlib
-import os
 import time
 from pathlib import Path
 
@@ -38,30 +36,36 @@ def read_tool(workspace: Workspace):
     return ReadTool(workspace)
 
 
-class TestWriteNewFile:
-    def test_write_new_file_no_mtime_check(self, write_tool, tmp_path: Path):
+class TestWritePreview:
+    def test_write_returns_preview(self, write_tool, tmp_path: Path):
         result = write_tool.write("new_file.txt", "hello")
-        assert "success" in result.lower()
+        assert "Write Preview" in result
+        assert "Snapshot ID:" in result
 
-    def test_write_new_file_creates_snapshot(self, write_tool, tmp_path: Path):
+    def test_write_does_not_write_to_disk(self, write_tool, tmp_path: Path):
+        write_tool.write("new_file.txt", "hello")
+        assert not (tmp_path / "new_file.txt").is_file()
+
+    def test_write_creates_snapshot(self, write_tool, tmp_path: Path):
         write_tool.write("new_file.txt", "hello")
 
-        rows = write_tool.workspace.db.fetchall("SELECT old_hash, new_hash, audit_status FROM file_snapshots")
+        rows = write_tool.workspace.db.fetchall(
+            "SELECT old_hash, new_hash, audit_status, pending_content FROM file_snapshots"
+        )
         assert len(rows) == 1
-        assert rows[0][0] is None
+        assert rows[0][0] is None  # old_hash for new file
         assert rows[0][2] == "PENDING_AUDIT"
+        assert rows[0][3] == "hello"
+
+    def test_write_preview_contains_diff(self, write_tool, tmp_path: Path):
+        write_tool.write("new_file.txt", "line1\nline2\nline3")
+        rows = write_tool.workspace.db.fetchall("SELECT diff_content FROM file_snapshots")
+        assert len(rows) == 1
+        assert "+line1" in rows[0][0]
 
 
 class TestWriteAfterRead:
-    def test_write_after_read_succeeds(self, write_tool, read_tool, tmp_path: Path):
-        file = tmp_path / "test.txt"
-        file.write_text("original", encoding="utf-8")
-
-        read_tool.read("test.txt")
-        result = write_tool.write("test.txt", "updated")
-        assert "success" in result.lower()
-
-    def test_write_after_read_has_old_hash(self, write_tool, read_tool, tmp_path: Path):
+    def test_write_after_read_contains_old_hash(self, write_tool, read_tool, tmp_path: Path):
         file = tmp_path / "test.txt"
         file.write_text("original", encoding="utf-8")
 
@@ -73,6 +77,19 @@ class TestWriteAfterRead:
         assert rows[0][0] is not None
         assert rows[0][1] != rows[0][0]
 
+    def test_write_after_read_shows_diff(self, write_tool, read_tool, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("line1\nline2\nline3", encoding="utf-8")
+
+        read_tool.read("test.txt")
+        result = write_tool.write("test.txt", "line1\nmodified\nline3")
+
+        assert "Write Preview" in result
+        rows = write_tool.workspace.db.fetchall("SELECT diff_content FROM file_snapshots")
+        assert len(rows) == 1
+        assert "-line2" in rows[0][0]
+        assert "+modified" in rows[0][0]
+
 
 class TestWriteModifiedExternally:
     def test_write_modified_externally_fails(self, write_tool, read_tool, tmp_path: Path):
@@ -82,16 +99,13 @@ class TestWriteModifiedExternally:
         read_tool.read("test.txt")
 
         file.write_text("modified externally", encoding="utf-8")
-        # 确保文件系统时间戳更新，Windows需要更长的延迟
         time.sleep(0.1)
 
-        # 确保文件修改时间确实变化了
         new_mtime = file.stat().st_mtime
         read_record = read_tool.workspace.db.get_file_read_record("test.txt")
         stored_mtime = read_record[2] if read_record else None
 
         if stored_mtime and abs(new_mtime - stored_mtime) < 0.001:
-            # 如果时间戳变化不够，手动修改文件以确保差异
             file.write_text("modified externally again", encoding="utf-8")
             time.sleep(0.1)
 
@@ -103,42 +117,36 @@ class TestWriteModifiedExternally:
         file.write_text("existing content", encoding="utf-8")
 
         result = write_tool.write("test.txt", "new content")
-        assert "success" in result.lower()
+        assert "Write Preview" in result
 
 
-class TestWriteDiffContent:
-    def test_write_diff_content(self, write_tool, tmp_path: Path):
-        file = tmp_path / "test.txt"
-        file.write_text("line1\nline2\nline3", encoding="utf-8")
+class TestWriteSnapshotPendingContent:
+    def test_pending_content_stored(self, write_tool, tmp_path: Path):
+        write_tool.write("new_file.txt", "pending content here")
 
-        from src.workspace.tools.read_tool import ReadTool
-
-        ReadTool(write_tool.workspace).read("test.txt")
-        write_tool.write("test.txt", "line1\nmodified\nline3")
-
-        rows = write_tool.workspace.db.fetchall("SELECT diff_content FROM file_snapshots")
+        rows = write_tool.workspace.db.fetchall("SELECT pending_content FROM file_snapshots")
         assert len(rows) == 1
-        assert "-line2" in rows[0][0]
-        assert "+modified" in rows[0][0]
+        assert rows[0][0] == "pending content here"
 
-    def test_write_new_file_no_diff(self, write_tool, tmp_path: Path):
-        write_tool.write("new_file.txt", "brand new")
-
-        rows = write_tool.workspace.db.fetchall("SELECT diff_content FROM file_snapshots")
-        assert len(rows) == 1
-        assert "+brand new" in rows[0][0]
-
-
-class TestWriteUpdatesReadRecord:
-    def test_write_updates_read_record(self, write_tool, read_tool, tmp_path: Path):
+    def test_pending_content_for_existing_file(self, write_tool, read_tool, tmp_path: Path):
         file = tmp_path / "test.txt"
         file.write_text("original", encoding="utf-8")
 
         read_tool.read("test.txt")
-        record_before = write_tool.workspace.db.get_file_read_record("test.txt")
-
         write_tool.write("test.txt", "updated content")
-        record_after = write_tool.workspace.db.get_file_read_record("test.txt")
 
-        assert record_after is not None
-        assert record_after[4] != record_before[4]
+        snap = write_tool.workspace.db.fetchone(
+            "SELECT pending_content, audit_status FROM file_snapshots WHERE file_path = 'test.txt'"
+        )
+        assert snap is not None
+        assert snap[0] == "updated content"
+        assert snap[1] == "PENDING_AUDIT"
+
+    def test_disk_file_unchanged_after_write(self, write_tool, read_tool, tmp_path: Path):
+        file = tmp_path / "test.txt"
+        file.write_text("original", encoding="utf-8")
+
+        read_tool.read("test.txt")
+        write_tool.write("test.txt", "should not change disk")
+
+        assert file.read_text(encoding="utf-8") == "original"

--- a/tests/workspace/tools/test_write_tool.py
+++ b/tests/workspace/tools/test_write_tool.py
@@ -82,7 +82,18 @@ class TestWriteModifiedExternally:
         read_tool.read("test.txt")
 
         file.write_text("modified externally", encoding="utf-8")
-        time.sleep(0.01)
+        # 确保文件系统时间戳更新，Windows需要更长的延迟
+        time.sleep(0.1)
+
+        # 确保文件修改时间确实变化了
+        new_mtime = file.stat().st_mtime
+        read_record = read_tool.workspace.db.get_file_read_record("test.txt")
+        stored_mtime = read_record[2] if read_record else None
+
+        if stored_mtime and abs(new_mtime - stored_mtime) < 0.001:
+            # 如果时间戳变化不够，手动修改文件以确保差异
+            file.write_text("modified externally again", encoding="utf-8")
+            time.sleep(0.1)
 
         result = write_tool.write("test.txt", "should fail")
         assert "FILE_MODIFIED_EXTERNALLY" in result


### PR DESCRIPTION
### Overview / 概述

This PR implements the core feature enhancements for the second phase of ManualAid, including the safe editing toolchain (two-phase commit audit mechanism), Git whitelist command encapsulation, audit tab UI, session statistics panel, as well as multiple stability fixes and UI optimizations. / 本 PR 实现了 ManualAid 第二阶段的核心功能增强，包括安全编辑工具链（两阶段提交审核机制）、Git 白名单命令封装、审计标签页 UI、会话统计面板，以及多项稳定性修复和 UI 优化

Contains **7 commits** spanning from 2026-04-29 to 2026-04-30. / 包含 7 个提交，时间跨度 2026-04-29 ~ 2026-04-30

---

### New Features / 新增功能

#### 1. Core Tool Enhancements — Safe Editing & Two-Phase Commit / 核心工具增强 — 安全编辑与两阶段提交

- **EditTool**: Safe string replacement editing with `context_before`/`context_after` context validation and `max_replacements` limit / EditTool：安全字符串替换编辑，支持 context_before/context_after 上下文校验和 max_replacements 限制
- **GitTool**: Whitelist-based safe encapsulation with three-level classification / GitTool：白名单安全封装，三级分类
  - Safe commands (e.g., `status`, `log`) execute directly without audit / 安全命令（如 status、log）免审直接执行
  - Modification commands (e.g., `add`, `commit`) require audit / 修改命令（如 add、commit）标记需审核
  - Dangerous commands are blocked directly / 禁止命令直接拦截
- **WriteTool**: Changed to preview mode, no longer writes to disk directly, creates `PENDING_AUDIT` snapshot / WriteTool：改为预览模式，不再直接写盘，发布 PENDING_AUDIT 快照
- **AuditCommitter**: Post-audit write module, new files go through `create_file_with_parents`, existing files verify mtime to prevent conflicts / AuditCommitter：审核后写盘模块，新文件走 create_file_with_parents，已有文件校验 mtime 防冲突

#### 2. Audit Tab / 审计标签页

- Textual third tab displaying all `PENDING_AUDIT` snapshots / Textual 第三标签页，展示所有 PENDING_AUDIT 快照
- Supports approve/reject operations / 支持批准 / 拒绝操作
- Asynchronous DOM mounting without blocking UI thread / 异步 DOM 挂载，不阻塞 UI 线程
- Differentiated styling with long list scrolling support / 差异化样式展示，支持长列表滚动

#### 3. Session Statistics Panel / 会话统计面板

- New `StatsTab` component for global and per-session tool usage ranking / 新增 StatsTab 组件，全局与单会话维度工具调用排名
- `DatabaseManager` extensions: `get_session_summary`, `get_all_sessions`, `rename_session`, `delete_session`, `get_tool_usage_ranking` / DatabaseManager 扩展：get_session_summary、get_all_sessions、rename_session、delete_session、get_tool_usage_ranking
- Real-time session duration display (updates every second) / 实时会话时长显示（每秒更新）
- Session rename/delete interactive dialogs / 会话重命名 / 删除交互对话框

---

### Fixed Issues / 修复问题

| Category / 类别 | Description / 描述 |
|------|------|
| **Windows Compatibility / Windows 兼容性** | NTFS timestamp precision issue causing `mtime` detection failure, added extra write fallback logic / NTFS 时间戳精度问题导致 mtime 检测失败，增加额外写入兜底逻辑 |
| **UI Rendering / UI 渲染** | Audit diff content height overflow, added `max-height` and `overflow-y: auto` / 审计差异内容高度溢出，添加 max-height 和 overflow-y: auto |
| **UI Components / UI 组件** | Fixed `#tools-result-collapsibles` → `#tools-result-collapsible` ID mismatch / 修正 #tools-result-collapsibles → #tools-result-collapsible ID 不匹配 |
| **Async Interaction / 异步交互** | Changed `AuditTab._refresh` and `on_button_pressed` to `async` to prevent UI blocking / 修正 AuditTab._refresh 和 on_button_pressed 改为 async，避免 UI 阻塞 |
| **Race Conditions / 竞态条件** | Replaced direct call with `set_timer` for `set_committer` refresh logic / set_committer 刷新逻辑改用 set_timer 代替直接调用 |
| **Git Robustness / Git 健壮性** | Force `GIT_PAGER=cat` / `GIT_TERMINAL_PROMPT=0` in `subprocess.run` to disable interaction; add null protection for `stdout`/`stderr` / subprocess.run 强制 GIT_PAGER=cat / GIT_TERMINAL_PROMPT=0 禁用交互；stdout/stderr 空值防护 |

---

### Architecture Changes / 架构变更

- **Database / 数据库**: Added `pending_content` column and related query methods to `file_snapshots` table / file_snapshots 表新增 pending_content 列及相关查询方法
- **ToolRegistry / 工具注册表**: Three-level classification `query` / `edit` / `dangerous`, Git determines audit status by subcommand / 工具三级分类 query / edit / dangerous，Git 按子命令判定审核状态
- **Two-Phase Commit / 两阶段提交**: Writes/edits only record snapshots → user audits in AuditTab → actual write after approval / 写入/编辑仅记录快照 → 用户在 AuditTab 审核 → 批准后实际写盘

---

### Code Quality / 代码质量

- Improved unit tests: `TestSessionSummary`, `TestAllSessions`, `TestRenameSession`, etc. / 完善 TestSessionSummary、TestAllSessions、TestRenameSession 等单元测试
- Type annotation fix: `_log_tool_call` return type from `None` to `str | None` / 类型注解修正：_log_tool_call 返回类型 None → str | None