### PR TITLE
ci(github): 支持 develop 分支触发 CI 流程 / enable-ci-workflows-for-prs-targeting-the-develop-branch (#66)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - develop
   push:
     branches:
       - main
+      - develop
 
 permissions:
   contents: read


### PR DESCRIPTION
fix #66 