### PR TITLE
fix(tools): 修复 to_doc 方法生成的 XML 标签不匹配问题

### DIFF
--- a/src/workspace/tools/base_tool.py
+++ b/src/workspace/tools/base_tool.py
@@ -121,7 +121,7 @@ class BaseTool:
             lines.append("    </params>")
         else:
             lines.append("    <params><!-- 此工具不需要参数 --></params>")
-        lines.append("</tool>")
+        lines.append("</func_name>")
         return "\n".join(lines)
 
     def to_func_call(self) -> str:

--- a/tests/workspace/tools/test_base_tool.py
+++ b/tests/workspace/tools/test_base_tool.py
@@ -86,7 +86,7 @@ def test_to_doc_new_format():
     assert "<description>测试工具</description>" in doc
     assert "<params>" in doc
     assert "</params>" in doc
-    assert doc.endswith("</tool>")
+    assert doc.endswith("</func_name>")
 
     # 验证参数格式
     assert 'type="string"' in doc


### PR DESCRIPTION
- 修复问题: 修正 base_tool.py 中工具文档生成逻辑的标签闭合错误
  * 将 to_doc 方法末尾硬编码的 `</tool>` 标签更正为动态变量 `</func_name>`
  * 确保生成的 XML 结构与 `<func_name>` 开始标签正确配对
 
fix #62 