### PR TITLE
fix(console): 修复工具处理器中错误信息的 XML 标签不匹配问题 (#59)

### DIFF
--- a/src/console/handlers/tool_handler.py
+++ b/src/console/handlers/tool_handler.py
@@ -134,7 +134,7 @@ class ToolHandler:
                     f"Error={e.__class__.__name__}({e}, {traceback.format_exc()})"
                 )
                 self.console.print(f"[red]{error}[/red]")
-                func_result = "\n".join(["", "<ErrorExecute>", error, "/<ErrorExecute>", ""])
+                func_result = "\n".join(["", "<ErrorExecute>", error, "</ErrorExecute>", ""])
                 self.console.print(f"[red]{error}[/red]")
 
             collection.add(func_name, time.perf_counter() - start, kwargs=func_kwargs, result=func_result)


### PR DESCRIPTION
- 修复问题: 修正 tool_handler.py 中异常捕获逻辑生成的 XML 闭合标签错误
  * 将 `<ErrorExecute>` 的闭合标签从错误的 `/<ErrorExecute>` 更正为 `</ErrorExecute>`
  * 确保 `func_result` 变量拼接的字符串符合标准 XML 格式规范