### PR TITLE
fix(tools): 修复 get_avg_consume 空记录异常 (#70)

### DIFF
--- a/src/models/tools/tool_result_collection.py
+++ b/src/models/tools/tool_result_collection.py
@@ -16,7 +16,8 @@ class ToolResultCollection:
         self.results[name].append((kwargs, result))
 
     def get_avg_consume(self, name: str) -> float:
-        return mean(self.consumes.get(name, []))
+        records = self.consumes.get(name, [])
+        return mean(records) if records else 0.0
 
     def tools(self) -> list[str]:
         return list(self.consumes.keys())


### PR DESCRIPTION
- 修复问题: 解决 `get_avg_consume` 在 `self.consumes` 中无对应记录时抛出异常的问题
  * 修改 `get_avg_consume` 方法逻辑，增加对 `records` 列表的空值判断
  * 当 `records` 为空时返回默认值 `0.0`，避免调用 `mean()` 导致异常

fix #70 