### PR TITLE
fix(console): 修正 paste_reference 变量拼写错误 (#56)

### DIFF
--- a/src/console/ui/repl.py
+++ b/src/console/ui/repl.py
@@ -134,7 +134,7 @@ class REPL(App):
         self.command_handler: CommandHandler | None = None
         self.tool_handler: ToolHandler | None = None
 
-        self.paste_refence: PasteReference = PasteReference()
+        self.paste_reference: PasteReference = PasteReference()
 
         # 多行输入缓冲区(用于 func_call 跨行输入)
         self._multiline_buffer: list[str] = []
@@ -237,8 +237,8 @@ class REPL(App):
         if not text.strip():
             return
 
-        text = self.paste_refence.expand(text).replace("&quot;", '"')
-        self.paste_refence.clear()
+        text = self.paste_reference.expand(text).replace("&quot;", '"')
+        self.paste_reference.clear()
 
         # 单行模式下直接分发
         self._dispatch(text)
@@ -253,8 +253,8 @@ class REPL(App):
     def _insert_paste_text(self, text: str) -> None:
         """在主线程中插入粘贴的文本"""
         text_area = self.query_one("#input-field", TextArea)
-        if self.paste_refence.should_collapse(text):
-            text = self.paste_refence.collapsed(text)
+        if self.paste_reference.should_collapse(text):
+            text = self.paste_reference.collapsed(text)
         text_area.insert(text)
 
     def action_submit_text(self) -> None:


### PR DESCRIPTION
- 修复问题: 修正代码中变量名 `paste_refence` 的拼写错误，统一为 `paste_reference`
  * 更新类初始化中的实例变量定义
  * 更新 `_dispatch` 方法中对 `expand` 和 `clear` 方法的调用
  * 更新 `_insert_paste_text` 方法中对 `should_collapse` 和 `collapsed` 方法的调用
 
fix #56 