### PR TITLE
refactor(tools): 将_record_read_meta方法移至基类 (#57)

### DIFF
--- a/src/workspace/tools/base_tool.py
+++ b/src/workspace/tools/base_tool.py
@@ -1,7 +1,9 @@
 import inspect
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
+from src.core.file_tracker import FileTracker
 from src.workspace.workspace import Workspace
 
 
@@ -174,3 +176,12 @@ class BaseTool:
                 converted[param_name] = param_value
 
         return converted
+
+    def _record_read_meta(self, resolved_path: Path) -> None:
+        try:
+            meta = FileTracker.get_file_meta(resolved_path)
+            if meta:
+                rel_path = str(resolved_path.relative_to(self.workspace.root_path))
+                self.workspace.db.record_file_read(rel_path, meta["mtime"], meta["size"], meta["checksum"])
+        except Exception:
+            pass

--- a/src/workspace/tools/read_lines_tool.py
+++ b/src/workspace/tools/read_lines_tool.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from src.core.file_tracker import FileTracker
 from src.models.tool_error_response import ToolErrorResponse
 from src.workspace.path_validator import PathNotFoundError, WorkspaceBoundaryError
 from src.workspace.tools.base_tool import BaseTool
@@ -74,12 +73,3 @@ class ReadLinesTool(BaseTool):
             return ToolErrorResponse(self.__class__.__name__, err3).to_str()
         except Exception as err:
             return ToolErrorResponse(self.__class__.__name__, err).to_str()
-
-    def _record_read_meta(self, resolved_path: Path) -> None:
-        try:
-            meta = FileTracker.get_file_meta(resolved_path)
-            if meta:
-                rel_path = str(resolved_path.relative_to(self.workspace.root_path))
-                self.workspace.db.record_file_read(rel_path, meta["mtime"], meta["size"], meta["checksum"])
-        except Exception:
-            pass

--- a/src/workspace/tools/read_tool.py
+++ b/src/workspace/tools/read_tool.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-from src.core.file_tracker import FileTracker
 from src.models.tool_error_response import ToolErrorResponse
 from src.workspace.path_validator import PathNotFoundError, WorkspaceBoundaryError
 from src.workspace.tools.base_tool import BaseTool
@@ -58,12 +57,3 @@ class ReadTool(BaseTool):
             return ToolErrorResponse(self.__class__.__name__, err3).to_str()
         except Exception as err:
             return ToolErrorResponse(self.__class__.__name__, err).to_str()
-
-    def _record_read_meta(self, resolved_path: Path) -> None:
-        try:
-            meta = FileTracker.get_file_meta(resolved_path)
-            if meta:
-                rel_path = str(resolved_path.relative_to(self.workspace.root_path))
-                self.workspace.db.record_file_read(rel_path, meta["mtime"], meta["size"], meta["checksum"])
-        except Exception:
-            pass


### PR DESCRIPTION
- 重构优化: 消除代码重复并统一文件读取元数据记录逻辑
  * 从`read_tool.py`中移除重复的`_record_read_meta`方法实现
  * 从`read_lines_tool.py`中移除重复的`_record_read_meta`方法实现
  * 在`base_tool.py`中添加`_record_read_meta`私有方法，调用`FileTracker.get_file_meta`获取元数据
  * 新实现通过`self.workspace.db.record_file_read`记录文件的相对路径、修改时间、大小及校验和

fix #57 