### PR TITLE
feat(workspace): 添加二进制文件安全拦截机制 (#77)

### DIFF
--- a/src/core/audit_committer.py
+++ b/src/core/audit_committer.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from src.utils.binary_detector import is_binary_file
 from src.workspace.workspace import Workspace
 
 
@@ -51,9 +52,14 @@ class AuditCommitter:
             db.update_snapshot_audit(snapshot_id, "REJECTED")
             return f"已拒绝 (snapshot_id={snapshot_id})"
 
-        # 3. 批准 — 执行写入
+        # 3. 批准 -- 执行写入
         try:
             resolved = self.workspace.path_validator.resolve_path(Path(file_path))
+
+            # 最后安全网:阻止写入二进制文件
+            if is_binary_file(resolved):
+                db.update_snapshot_audit(snapshot_id, "REJECTED")
+                return f"安全拦截: 禁止写入二进制文件 {file_path} (snapshot_id={snapshot_id})"
 
             if not resolved.exists():
                 # 全新文件 — 使用 create_file_with_parents

--- a/src/utils/binary_detector.py
+++ b/src/utils/binary_detector.py
@@ -1,0 +1,159 @@
+"""二进制文件检测工具模块.
+
+提供统一的二进制文件判断逻辑:
+1. 常见二进制后缀名直接判定为二进制文件
+2. 否则尝试以指定编码解码前 512 字节,解码失败则认为是二进制文件或编码错误
+"""
+
+from pathlib import Path
+
+# 常见二进制文件扩展名(小写)
+BINARY_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        # 可执行文件
+        ".exe",
+        ".dll",
+        ".so",
+        ".dylib",
+        ".bin",
+        ".com",
+        ".msi",
+        ".bat",
+        # 压缩文件
+        ".zip",
+        ".tar",
+        ".gz",
+        ".bz2",
+        ".xz",
+        ".7z",
+        ".rar",
+        ".zst",
+        ".tgz",
+        ".tbz2",
+        ".txz",
+        # 图片文件
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".bmp",
+        ".ico",
+        ".webp",
+        ".tiff",
+        ".tif",
+        ".svg",
+        ".psd",
+        ".raw",
+        ".heic",
+        ".avif",
+        # 音视频文件
+        ".mp3",
+        ".mp4",
+        ".avi",
+        ".mkv",
+        ".mov",
+        ".wmv",
+        ".flv",
+        ".wav",
+        ".ogg",
+        ".flac",
+        ".aac",
+        ".m4a",
+        ".m4v",
+        ".webm",
+        # 文档/电子书
+        ".pdf",
+        ".doc",
+        ".docx",
+        ".xls",
+        ".xlsx",
+        ".ppt",
+        ".pptx",
+        ".odt",
+        ".ods",
+        ".odp",
+        ".epub",
+        ".mobi",
+        ".rtf",
+        # 数据/序列化
+        ".pickle",
+        ".pkl",
+        ".parquet",
+        ".arrow",
+        ".feather",
+        ".h5",
+        ".hdf5",
+        # 其他
+        ".pyc",
+        ".pyo",
+        ".whl",
+        ".egg",
+        ".deb",
+        ".rpm",
+        ".dmg",
+        ".iso",
+        ".img",
+        ".vhd",
+        ".ova",
+        ".apk",
+        ".aab",
+        ".ipa",
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".otf",
+        ".eot",
+        ".db",
+        ".sqlite",
+        ".sqlite3",
+        ".env",
+    }
+)
+
+# 解码检测时读取的最大字节数
+_DETECTION_CHUNK_SIZE = 512
+
+
+def is_binary_file(path: str | Path, encoding: str = "utf-8") -> bool:
+    """判断给定路径是否为二进制文件.
+
+    判定策略:
+    1. 如果文件不存在,仅通过扩展名判断(适用于写入前的预检查)
+    2. 如果扩展名在已知二进制列表中,直接返回 True
+    3. 否则读取文件前 512 字节,尝试以指定编码解码;解码失败则认为是二进制文件
+
+    Args:
+        path: 文件路径
+        encoding: 尝试解码时使用的编码,默认 "utf-8"
+
+    Returns:
+        True 表示是二进制文件, False 表示可能是文本文件
+    """
+    p = Path(path)
+    suffix = p.suffix.lower()
+
+    # 策略1: 扩展名匹配
+    if suffix in BINARY_EXTENSIONS:
+        return True
+
+    # 策略2: 文件不存在时,无法通过内容判断,返回 False(允许创建)
+    if not p.exists():
+        return False
+
+    # 策略3: 尝试以指定编码解码文件头部
+    try:
+        with open(p, "rb") as f:
+            chunk = f.read(_DETECTION_CHUNK_SIZE)
+        if not chunk:
+            # 空文件视为文本文件
+            return False
+        # 即使解码成功,null 字节也几乎不可能出现在合法文本文件中
+        if b"\x00" in chunk:
+            return True
+        chunk.decode(encoding)
+        return False
+    except UnicodeDecodeError, ValueError:
+        return True
+    except OSError:
+        # 文件无法读取(权限等),保守返回 False
+        return False

--- a/src/workspace/tools/edit_tool.py
+++ b/src/workspace/tools/edit_tool.py
@@ -1,8 +1,9 @@
-"""安全的字符串替换编辑工具 — 只发布待审核更改."""
+"""安全的字符串替换编辑工具 -- 只发布待审核更改."""
 
 from pathlib import Path
 
 from src.models.tool_error_response import ToolErrorResponse
+from src.utils.binary_detector import is_binary_file
 from src.workspace.tools.base_tool import BaseTool
 from src.workspace.workspace import Workspace
 
@@ -61,6 +62,12 @@ class EditTool(BaseTool):
             return ToolErrorResponse(
                 self.__class__.__name__,
                 FileNotFoundError(f"文件不存在: {resolved_path}"),
+            ).to_str()
+
+        if is_binary_file(resolved_path):
+            return ToolErrorResponse(
+                self.__class__.__name__,
+                ValueError(f"禁止编辑二进制文件: {resolved_path}"),
             ).to_str()
 
         # 3. mtime 校验

--- a/src/workspace/tools/read_lines_tool.py
+++ b/src/workspace/tools/read_lines_tool.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from src.models.tool_error_response import ToolErrorResponse
+from src.utils.binary_detector import is_binary_file
 from src.workspace.tools.base_tool import BaseTool
 from src.workspace.workspace import Workspace
 
@@ -28,6 +29,12 @@ class ReadLinesTool(BaseTool):
 
         if not path.is_file():
             return ToolErrorResponse(self.__class__.__name__, ValueError(f"读取文件{path}时未读取到完整文件")).to_str()
+
+        if is_binary_file(path, encoding=encoding):
+            return ToolErrorResponse(
+                self.__class__.__name__,
+                ValueError(f"无法读取二进制文件: {path}. 请使用二进制安全工具或转换为 base64."),
+            ).to_str()
 
         with open(path, encoding=encoding) as f:
             lines = f.readlines()

--- a/src/workspace/tools/read_tool.py
+++ b/src/workspace/tools/read_tool.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from src.models.tool_error_response import ToolErrorResponse
+from src.utils.binary_detector import is_binary_file
 from src.workspace.tools.base_tool import BaseTool
 from src.workspace.workspace import Workspace
 
@@ -26,6 +27,12 @@ class ReadTool(BaseTool):
 
         if not path.is_file():
             return ToolErrorResponse(self.__class__.__name__, ValueError(f"读取文件{path}时未读取到完整文件")).to_str()
+
+        if is_binary_file(path, encoding=encoding):
+            return ToolErrorResponse(
+                self.__class__.__name__,
+                ValueError(f"无法读取二进制文件: {path}. 请使用二进制安全工具或转换为 base64."),
+            ).to_str()
 
         with open(path, encoding=encoding) as f:
             lines = f.readlines()

--- a/src/workspace/tools/write_tool.py
+++ b/src/workspace/tools/write_tool.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from src.core.file_tracker import FileTracker
 from src.models.tool_error_response import ToolErrorResponse
+from src.utils.binary_detector import is_binary_file
 from src.workspace.tools.base_tool import BaseTool
 from src.workspace.workspace import Workspace
 
@@ -28,6 +29,12 @@ class WriteTool(BaseTool):
         if file_path.exists() and file_path.is_dir():
             return ToolErrorResponse(
                 self.__class__.__name__, ValueError(f"路径 {file_path} 是一个目录,无法写入")
+            ).to_str()
+
+        if is_binary_file(file_path):
+            return ToolErrorResponse(
+                self.__class__.__name__,
+                ValueError(f"禁止写入二进制文件: {file_path}"),
             ).to_str()
 
         mtime_error = self._validate_mtime(file_path)

--- a/tests/core/test_audit_committer.py
+++ b/tests/core/test_audit_committer.py
@@ -142,3 +142,39 @@ class TestCommitEdgeCases:
 
         result = committer.commit(snapshot_id, approved=False)
         assert "已处理" in result
+
+
+class TestCommitBinaryProtection:
+    """测试审计提交器的二进制文件安全网."""
+
+    def test_commit_binary_ext_blocked(self, committer: AuditCommitter, workspace: Workspace):
+        """批准写入 .png 文件应被安全网拦截."""
+        snapshot_id = _create_pending_snapshot(workspace, "image.png", "fake png")
+        result = committer.commit(snapshot_id, approved=True)
+
+        assert "二进制文件" in result
+        assert not (workspace.root_path / "image.png").is_file()
+        # 状态应被标记为 REJECTED
+        snap = workspace.db.get_snapshot_by_id(snapshot_id)
+        assert snap[7] == "REJECTED"
+
+    def test_commit_binary_content_blocked(self, committer: AuditCommitter, workspace: Workspace):
+        """批准写入内容为二进制的文件应被安全网拦截."""
+        # 先在磁盘上创建一个二进制文件
+        target = workspace.root_path / "data.unknown"
+        target.write_bytes(b"\x00\xff\xfe")
+
+        snapshot_id = _create_pending_snapshot(workspace, "data.unknown", "overwrite")
+        result = committer.commit(snapshot_id, approved=True)
+
+        assert "二进制文件" in result
+        # 文件内容不应被改变
+        assert target.read_bytes() == b"\x00\xff\xfe"
+
+    def test_commit_text_file_not_blocked(self, committer: AuditCommitter, workspace: Workspace):
+        """批准写入文本文件应正常通过."""
+        snapshot_id = _create_pending_snapshot(workspace, "notes.txt", "hello")
+        result = committer.commit(snapshot_id, approved=True)
+
+        assert "已批准" in result
+        assert (workspace.root_path / "notes.txt").read_text(encoding="utf-8") == "hello"

--- a/tests/utils/test_binary_detector.py
+++ b/tests/utils/test_binary_detector.py
@@ -1,0 +1,193 @@
+"""二进制文件检测工具的单元测试."""
+
+from pathlib import Path
+
+import pytest
+
+from src.utils.binary_detector import BINARY_EXTENSIONS, is_binary_file
+
+
+class TestBinaryExtensionDetection:
+    """测试基于扩展名的二进制文件检测."""
+
+    @pytest.mark.parametrize(
+        "ext",
+        [
+            ".exe",
+            ".dll",
+            ".so",
+            ".bin",
+            ".zip",
+            ".png",
+            ".jpg",
+            ".mp3",
+            ".mp4",
+            ".pdf",
+            ".doc",
+            ".pyc",
+            ".whl",
+            ".woff",
+            ".sqlite",
+            ".env",
+            ".gz",
+            ".7z",
+            ".webp",
+            ".svg",
+            ".ttf",
+        ],
+    )
+    def test_known_binary_extensions(self, tmp_path: Path, ext: str):
+        """已知二进制扩展名应被检测为二进制文件."""
+        f = tmp_path / f"test{ext}"
+        f.write_bytes(b"\x00")
+        assert is_binary_file(f) is True
+
+    @pytest.mark.parametrize(
+        "ext",
+        [
+            ".txt",
+            ".py",
+            ".js",
+            ".ts",
+            ".md",
+            ".json",
+            ".yaml",
+            ".yml",
+            ".toml",
+            ".cfg",
+            ".ini",
+            ".csv",
+            ".xml",
+            ".html",
+            ".css",
+            ".sh",
+            ".bash",
+            ".zsh",
+            ".c",
+            ".h",
+            ".cpp",
+            ".hpp",
+            ".rs",
+            ".go",
+            ".java",
+            ".kt",
+            ".rb",
+            ".php",
+            ".sql",
+            ".log",
+        ],
+    )
+    def test_known_text_extensions(self, tmp_path: Path, ext: str):
+        """已知文本扩展名应不被检测为二进制文件."""
+        f = tmp_path / f"test{ext}"
+        f.write_text("hello world", encoding="utf-8")
+        assert is_binary_file(f) is False
+
+    def test_extension_case_insensitive(self, tmp_path: Path):
+        """扩展名检测应不区分大小写."""
+        f = tmp_path / "test.PNG"
+        f.write_bytes(b"\x00")
+        assert is_binary_file(f) is True
+
+    def test_extension_without_dot(self, tmp_path: Path):
+        """无扩展名的文件不应被扩展名规则匹配."""
+        f = tmp_path / "Makefile"
+        f.write_text("all:", encoding="utf-8")
+        assert is_binary_file(f) is False
+
+
+class TestBinaryContentDetection:
+    """测试基于文件内容的二进制文件检测."""
+
+    def test_null_bytes_in_content(self, tmp_path: Path):
+        """包含 null 字节的内容应被检测为二进制."""
+        f = tmp_path / "data.dat"
+        f.write_bytes(b"hello\x00world")
+        assert is_binary_file(f) is True
+
+    def test_invalid_utf8_sequence(self, tmp_path: Path):
+        """无效 UTF-8 字节序列应被检测为二进制."""
+        f = tmp_path / "data.unknown"
+        f.write_bytes(b"\xff\xfe\xfd\xfc")
+        assert is_binary_file(f) is True
+
+    def test_valid_utf8_content(self, tmp_path: Path):
+        """有效的 UTF-8 文本内容不应被检测为二进制."""
+        f = tmp_path / "data.unknown"
+        f.write_text("这是一段中文文本\nwith english", encoding="utf-8")
+        assert is_binary_file(f) is False
+
+    def test_empty_file(self, tmp_path: Path):
+        """空文件不应被检测为二进制."""
+        f = tmp_path / "empty.unknown"
+        f.write_bytes(b"")
+        assert is_binary_file(f) is False
+
+    def test_small_file(self, tmp_path: Path):
+        """小于 512 字节的文件也能正确检测."""
+        f = tmp_path / "small.unknown"
+        f.write_bytes(b"\x01\x02\x03\xff")
+        assert is_binary_file(f) is True
+
+    def test_large_file_only_reads_header(self, tmp_path: Path):
+        """大文件只检测前 512 字节."""
+        f = tmp_path / "large.unknown"
+        # 前 512 字节是有效 UTF-8,后面是二进制
+        header = "x" * 512
+        binary_tail = b"\xff" * 1024
+        f.write_bytes(header.encode("utf-8") + binary_tail)
+        assert is_binary_file(f) is False
+
+
+class TestEncodingParameter:
+    """测试 encoding 参数对检测的影响."""
+
+    def test_gb18030_encoded_file_with_utf8_detection(self, tmp_path: Path):
+        """GB18030 编码的中文文件在 UTF-8 检测下应被判为二进制."""
+        f = tmp_path / "chinese.txt"
+        # GB18030 编码的 "中文"
+        f.write_bytes(b"\xd6\xd0\xce\xc4")
+        assert is_binary_file(f, encoding="utf-8") is True
+
+    def test_gb18030_encoded_file_with_gb18030_detection(self, tmp_path: Path):
+        """GB18030 编码的文件在 GB18030 检测下应不被判为二进制."""
+        f = tmp_path / "chinese.txt"
+        f.write_bytes(b"\xd6\xd0\xce\xc4")
+        assert is_binary_file(f, encoding="gb18030") is False
+
+
+class TestNonExistentFile:
+    """测试文件不存在时的行为."""
+
+    def test_nonexistent_with_binary_ext(self, tmp_path: Path):
+        """不存在的文件如果扩展名为二进制,仍应返回 True."""
+        f = tmp_path / "new.exe"
+        assert is_binary_file(f) is True
+
+    def test_nonexistent_with_text_ext(self, tmp_path: Path):
+        """不存在的文件如果扩展名为文本,应返回 False(允许创建)."""
+        f = tmp_path / "new.txt"
+        assert is_binary_file(f) is False
+
+    def test_nonexistent_without_ext(self, tmp_path: Path):
+        """不存在的文件如果无扩展名,应返回 False."""
+        f = tmp_path / "newfile"
+        assert is_binary_file(f) is False
+
+
+class TestBinaryExtensionsSet:
+    """测试 BINARY_EXTENSIONS 常量的完整性."""
+
+    def test_is_frozenset(self):
+        """BINARY_EXTENSIONS 应为 frozenset,防止意外修改."""
+        assert isinstance(BINARY_EXTENSIONS, frozenset)
+
+    def test_all_lower_case(self):
+        """所有扩展名应为小写."""
+        for ext in BINARY_EXTENSIONS:
+            assert ext == ext.lower(), f"扩展名 {ext} 不是小写"
+
+    def test_all_start_with_dot(self):
+        """所有扩展名应以点号开头."""
+        for ext in BINARY_EXTENSIONS:
+            assert ext.startswith("."), f"扩展名 {ext} 不以点号开头"

--- a/tests/workspace/tools/test_binary_protection.py
+++ b/tests/workspace/tools/test_binary_protection.py
@@ -1,0 +1,204 @@
+"""二进制文件保护机制的集成测试.
+
+验证 read/read_lines/write/edit 工具在遇到二进制文件时的行为:
+- read/read_lines: 返回明确的二进制文件错误提示
+- write/edit: 阻止对二进制文件的操作
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.core.database_manager import DatabaseManager
+from src.workspace.workspace import Workspace
+
+
+@pytest.fixture(autouse=True)
+def reset_singletons():
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+    yield
+    Workspace._instance = None
+    DatabaseManager.reset_instances()
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Workspace:
+    ws = Workspace(str(tmp_path))
+    return ws
+
+
+@pytest.fixture
+def binary_file(tmp_path: Path) -> Path:
+    """创建一个二进制测试文件(无已知二进制扩展名,靠内容检测)."""
+    f = tmp_path / "data.unknown"
+    f.write_bytes(b"\x00\x01\x02\xff\xfe\xfd")
+    return f
+
+
+@pytest.fixture
+def binary_ext_file(tmp_path: Path) -> Path:
+    """创建一个通过扩展名识别的二进制文件."""
+    f = tmp_path / "image.png"
+    f.write_bytes(b"\x89PNG\r\n\x1a\nfake data")
+    return f
+
+
+@pytest.fixture
+def text_file(tmp_path: Path) -> Path:
+    """创建一个普通文本文件."""
+    f = tmp_path / "readme.txt"
+    f.write_text("hello world\nline two", encoding="utf-8")
+    return f
+
+
+class TestReadBinaryProtection:
+    """测试 read 工具的二进制保护."""
+
+    def test_read_binary_by_extension(self, workspace: Workspace, binary_ext_file: Path):
+        """通过扩展名检测到的二进制文件应被拒绝读取."""
+        from src.workspace.tools.read_tool import ReadTool
+
+        tool = ReadTool(workspace)
+        result = tool.read("image.png")
+
+        assert "二进制文件" in result
+
+    def test_read_binary_by_content(self, workspace: Workspace, binary_file: Path):
+        """通过内容检测到的二进制文件应被拒绝读取."""
+        from src.workspace.tools.read_tool import ReadTool
+
+        tool = ReadTool(workspace)
+        result = tool.read("data.unknown")
+
+        assert "二进制文件" in result
+
+    def test_read_text_file_still_works(self, workspace: Workspace, text_file: Path):
+        """文本文件读取应不受影响."""
+        from src.workspace.tools.read_tool import ReadTool
+
+        tool = ReadTool(workspace)
+        result = tool.read("readme.txt")
+
+        assert "hello world" in result
+        assert "二进制文件" not in result
+
+
+class TestReadLinesBinaryProtection:
+    """测试 read_lines 工具的二进制保护."""
+
+    def test_read_lines_binary_by_extension(self, workspace: Workspace, binary_ext_file: Path):
+        """通过扩展名检测到的二进制文件应被拒绝读取."""
+        from src.workspace.tools.read_lines_tool import ReadLinesTool
+
+        tool = ReadLinesTool(workspace)
+        result = tool.read_lines("image.png", 1, 10)
+
+        assert "二进制文件" in result
+
+    def test_read_lines_binary_by_content(self, workspace: Workspace, binary_file: Path):
+        """通过内容检测到的二进制文件应被拒绝读取."""
+        from src.workspace.tools.read_lines_tool import ReadLinesTool
+
+        tool = ReadLinesTool(workspace)
+        result = tool.read_lines("data.unknown", 1, 10)
+
+        assert "二进制文件" in result
+
+    def test_read_lines_text_file_still_works(self, workspace: Workspace, text_file: Path):
+        """文本文件读取应不受影响."""
+        from src.workspace.tools.read_lines_tool import ReadLinesTool
+
+        tool = ReadLinesTool(workspace)
+        result = tool.read_lines("readme.txt", 1, 2)
+
+        assert "hello world" in result
+        assert "二进制文件" not in result
+
+
+class TestWriteBinaryProtection:
+    """测试 write 工具的二进制保护."""
+
+    def test_write_binary_by_extension_blocked(self, workspace: Workspace, binary_ext_file: Path):
+        """写入已知二进制扩展名的文件应被阻止."""
+        from src.workspace.tools.write_tool import WriteTool
+
+        tool = WriteTool(workspace)
+        result = tool.write("image.png", "malicious content")
+
+        assert "二进制文件" in result
+        # 不应创建快照
+        rows = workspace.db.fetchall("SELECT * FROM file_snapshots")
+        assert len(rows) == 0
+
+    def test_write_binary_by_content_blocked(self, workspace: Workspace, binary_file: Path):
+        """写入通过内容检测到的二进制文件应被阻止."""
+        from src.workspace.tools.write_tool import WriteTool
+
+        tool = WriteTool(workspace)
+        result = tool.write("data.unknown", "overwrite attempt")
+
+        assert "二进制文件" in result
+        rows = workspace.db.fetchall("SELECT * FROM file_snapshots")
+        assert len(rows) == 0
+
+    def test_write_text_file_still_works(self, workspace: Workspace, text_file: Path):
+        """写入文本文件应不受影响."""
+        from src.workspace.tools.write_tool import WriteTool
+
+        tool = WriteTool(workspace)
+        result = tool.write("readme.txt", "new content")
+
+        assert "Write Preview" in result
+        assert "二进制文件" not in result
+
+    def test_write_new_binary_ext_blocked(self, workspace: Workspace):
+        """写入新的二进制扩展名文件(不存在)也应被阻止."""
+        from src.workspace.tools.write_tool import WriteTool
+
+        tool = WriteTool(workspace)
+        result = tool.write("new_app.exe", "fake exe content")
+
+        assert "二进制文件" in result
+
+    def test_write_new_text_ext_allowed(self, workspace: Workspace):
+        """写入新的文本扩展名文件应正常通过."""
+        from src.workspace.tools.write_tool import WriteTool
+
+        tool = WriteTool(workspace)
+        result = tool.write("new_file.py", "print('hello')")
+
+        assert "Write Preview" in result
+        assert "二进制文件" not in result
+
+
+class TestEditBinaryProtection:
+    """测试 edit 工具的二进制保护."""
+
+    def test_edit_binary_by_extension_blocked(self, workspace: Workspace, binary_ext_file: Path):
+        """编辑已知二进制扩展名的文件应被阻止."""
+        from src.workspace.tools.edit_tool import EditTool
+
+        tool = EditTool(workspace)
+        result = tool.edit("image.png", "fake", "replaced")
+
+        assert "二进制文件" in result
+
+    def test_edit_binary_by_content_blocked(self, workspace: Workspace, binary_file: Path):
+        """编辑通过内容检测到的二进制文件应被阻止."""
+        from src.workspace.tools.edit_tool import EditTool
+
+        tool = EditTool(workspace)
+        result = tool.edit("data.unknown", "test", "replaced")
+
+        assert "二进制文件" in result
+
+    def test_edit_text_file_still_works(self, workspace: Workspace, text_file: Path):
+        """编辑文本文件应不受影响."""
+        from src.workspace.tools.edit_tool import EditTool
+
+        tool = EditTool(workspace)
+        result = tool.edit("readme.txt", "hello", "hi")
+
+        assert "Edit Preview" in result
+        assert "二进制文件" not in result


### PR DESCRIPTION
- 新增功能: 实现二进制文件检测工具与扩展逻辑
  * 新增 `src/utils/binary_detector.py` 模块，定义 `BINARY_EXTENSIONS` 常量集合 (包含 exe, dll, zip, png 等 100+ 扩展名)
  * 新增 `is_binary_file(path, encoding)` 函数，采用“扩展名匹配” + “内容解码校验”双重策略判断文件类型
  * 检测逻辑支持读取前 512 字节并检查 null 字节 (`\x00`) 及 UTF-8 解码失败情况
- 修复问题: 在核心读写工具中集成二进制保护逻辑
  * `read_tool.py`: 在 `read()` 方法调用 `is_binary_file` 拦截，返回明确错误提示
  * `read_lines_tool.py`: 在 `read_lines()` 方法中增加相同拦截逻辑
  * `write_tool.py`: 在写入前通过 `is_binary_file` 检查，阻止对 `.png`, `.exe` 或含二进制内容的文件进行覆盖
  * `edit_tool.py`: 在 `edit()` 方法中增加检查，禁止修改二进制文件
  * `audit_committer.py`: 在 `commit()` 流程中添加最终安全网，即使快照已批准，若检测到二进制文件则标记为 `REJECTED`
- 文档更新: 补充单元测试验证防护有效性
  * 新增 `tests/utils/test_binary_detector.py` 覆盖扩展名大小写、空文件、无效编码序列等边界场景
  * 新增 `tests/workspace/tools/test_binary_protection.py` 验证 read/write/edit/commit 工具在遇到二进制文件时的拒绝行为
  * 更新 `tests/core/test_audit_committer.py` 增加针对二进制文件提交的测试用例

fix #77 