### PR TITLE
feat(console): 在工具调用统计表中增加总耗时列 (#86)

### DIFF
--- a/src/console/ui/widgets/stats_tab.py
+++ b/src/console/ui/widgets/stats_tab.py
@@ -327,10 +327,11 @@ class StatsTab(Vertical):
         if ranking:
             self.mount(Label("Top Tools", classes="stats-header"))
             dt = DataTable(id="stats-tool-ranking")
-            dt.add_columns("#", "Tool", "Calls", "Avg Time")
-            for i, (func_name, count, avg_dur) in enumerate(ranking, 1):
-                avg_str = f"{avg_dur:.1f}ms" if avg_dur else "N/A"
-                dt.add_row(str(i), func_name, str(count), avg_str)
+            dt.add_columns("#", "Tool", "Calls", "Avg Time", "Total Time")
+            for i, (func_name, count, avg_dur, total_dur) in enumerate(ranking, 1):
+                avg_str = f"{avg_dur:.1f}ms" if avg_dur is not None else "N/A"
+                total_str = f"{total_dur:.1f}ms" if total_dur is not None else "N/A"
+                dt.add_row(str(i), func_name, str(count), avg_str, total_str)
             self.mount(dt)
         else:
             self.mount(Label("No tool calls recorded yet.", id="stats-empty"))

--- a/src/core/database_manager.py
+++ b/src/core/database_manager.py
@@ -436,16 +436,16 @@ class DatabaseManager:
         self.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
 
     def get_tool_usage_ranking(self, session_id: int | None = None, limit: int = 10) -> list[tuple]:
-        """Returns list of (func_name, call_count, avg_duration_ms) ordered by count DESC."""
+        """Returns list of (func_name, call_count, avg_duration_ms, total_duration_ms) ordered by count DESC."""
         if session_id is not None:
             return self.fetchall(
-                "SELECT func_name, COUNT(*) as cnt, AVG(duration_ms) as avg_dur "
+                "SELECT func_name, COUNT(*) as cnt, AVG(duration_ms) as avg_dur, SUM(duration_ms) as total_dur "
                 "FROM tool_calls WHERE session_id = ? "
                 "GROUP BY func_name ORDER BY cnt DESC LIMIT ?",
                 (session_id, limit),
             )
         return self.fetchall(
-            "SELECT func_name, COUNT(*) as cnt, AVG(duration_ms) as avg_dur "
+            "SELECT func_name, COUNT(*) as cnt, AVG(duration_ms) as avg_dur, SUM(duration_ms) as total_dur "
             "FROM tool_calls "
             "GROUP BY func_name ORDER BY cnt DESC LIMIT ?",
             (limit,),

--- a/tests/core/test_database_manager.py
+++ b/tests/core/test_database_manager.py
@@ -498,6 +498,7 @@ class TestToolUsageRanking:
         assert ranking[0][0] == "read"
         assert ranking[0][1] == 2
         assert ranking[0][2] == pytest.approx(20.0)
+        assert ranking[0][3] == pytest.approx(40.0)
 
     def test_ranking_limit(self, db: DatabaseManager):
         sid = db.create_session()


### PR DESCRIPTION
- 新增功能: 扩展 `get_tool_usage_ranking` API 返回数据维度
  * 数据库查询逻辑更新，SQL 语句新增 `SUM(duration_ms) as total_dur` 聚合计算
  * API 返回值元组结构由 `(func_name, call_count, avg_duration_ms)` 变更为包含第四个元素 `total_duration_ms`
- 重构优化: 同步更新 UI 展示层以适配新数据结构
  * `src/console/ui/widgets/stats_tab.py` 中 `DataTable` 列定义增加 "Total Time"
  * 渲染循环解包逻辑调整为接收 `total_dur` 参数并格式化显示为毫秒字符串