### PR TITLE
fix(symbol_ref_tool): 修复符号搜索性能灾难及文本往返反模式 (#132)

### DIFF
--- a/src/workspace/tools/symbol_ref_tool.py
+++ b/src/workspace/tools/symbol_ref_tool.py
@@ -1,15 +1,11 @@
 """符号引用查找工具 - 查找函数、类、变量等的定义和引用"""
 
 import re
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 from src.models.tool_error_response import ToolErrorResponse
 from src.workspace.tools.base_tool import BaseTool
 from src.workspace.workspace import Workspace
-
-# 默认排除的目录(与 workspace.py 保持一致, 后续改为从项目配置加载)
-DEFAULT_EXCLUDED_DIRS = {".git", "__pycache__", "node_modules", ".venv", "venv", "dist", "build", ".idea", ".vscode"}
 
 
 def _get_file_pattern_by_language(language: str) -> str:
@@ -124,79 +120,7 @@ def _generate_patterns(symbol_name: str, language: str, include_def: bool, inclu
     return unique_patterns
 
 
-def _search_single_pattern(
-    workspace: Workspace,
-    pattern_info: dict,
-    search_path: str,
-    symbol_name: str,
-    context_lines: int,
-    limit: int,
-    file_pattern: str,
-    ignore: list[str] | None,
-) -> list[dict]:
-    """使用 Workspace.search_content 执行单个模式的搜索(并发版本)"""
-    results = []
-
-    try:
-        # 使用 workspace 的并发搜索能力
-        search_result = workspace.search_content(
-            pattern=pattern_info["pattern"],
-            folder_path=search_path,
-            file_pattern=file_pattern,
-            max_workers=4,  # 并发线程数
-            case_sensitive=False,
-        )
-
-        # 解析 search_content 的返回结果
-        if not search_result or "未找到匹配" in search_result:
-            return results
-
-        # 解析结果格式: search_content 返回的是格式化的字符串
-        # 格式: [文件] path\n----\n  行号 | 内容
-        lines = search_result.split("\n")
-        current_file = None
-        current_matches = []
-
-        for line in lines:
-            if line.startswith("[文件] "):
-                # 保存上一个文件的结果
-                if current_file and current_matches:
-                    results.append({"file": current_file, "matches": current_matches, "type": pattern_info["type"]})
-                current_file = line[6:]  # 去掉 "[文件] "
-                current_matches = []
-            elif line.startswith("----"):
-                continue
-            elif line.strip() and current_file:
-                # 解析匹配行: "  行号 | 内容"
-                match = re.match(r"\s+(\d+)\s*\|\s*(.*)", line)
-                if match:
-                    line_num = int(match.group(1))
-                    content = match.group(2)
-
-                    # 收集上下文(这里简化处理,因为 search_content 不直接提供上下文)
-                    # 为了保持兼容性,我们构建一个简化的上下文
-                    current_matches.append(
-                        {
-                            "line_num": line_num,
-                            "content": content,
-                            "context": [{"line_num": line_num, "content": content, "is_match": True}],
-                            "match_type": pattern_info["type"],
-                            "symbol_name": symbol_name,
-                        }
-                    )
-
-        # 保存最后一个文件的结果
-        if current_file and current_matches:
-            results.append({"file": current_file, "matches": current_matches, "type": pattern_info["type"]})
-
-    except Exception:
-        # 如果搜索失败,静默跳过
-        pass
-
-    return results
-
-
-def _search_patterns_concurrent(
+def _search_all_patterns(
     workspace: Workspace,
     patterns: list[dict],
     search_path: str,
@@ -206,40 +130,124 @@ def _search_patterns_concurrent(
     file_pattern: str,
     ignore: list[str] | None,
 ) -> list[dict]:
-    """并发执行多个模式的搜索"""
-    all_results = []
+    """单次文件遍历搜索所有模式, 返回按文件分组且带上下文的结果.
 
-    # 使用线程池并发执行多个模式的搜索
-    with ThreadPoolExecutor(max_workers=min(len(patterns), 4)) as executor:
-        future_to_pattern = {
-            executor.submit(
-                _search_single_pattern,
-                workspace,
-                pattern_info,
-                search_path,
-                symbol_name,
-                context_lines,
-                limit - len(all_results),
-                file_pattern,
-                ignore,
-            ): pattern_info
-            for pattern_info in patterns
-        }
+    相比旧实现的优势:
+    - 文件系统只遍历 1 次(旧: N 次, N=模式数量)
+    - 每个文件只读取 1 次(旧: N 次)
+    - 直接使用结构化数据, 无需 格式化→正则解析 的反模式
+    - 真正实现上下文行读取(旧实现仅将匹配行本身作为上下文)
+    """
+    # 编译所有正则模式
+    compiled_patterns: list[tuple[re.Pattern, str]] = []
+    for p in patterns:
+        try:
+            regex = re.compile(p["pattern"], re.IGNORECASE)
+            compiled_patterns.append((regex, p["type"]))
+        except re.error:
+            continue
 
-        for future in as_completed(future_to_pattern):
-            try:
-                results = future.result()
-                all_results.extend(results)
-                if len(all_results) >= limit:
-                    # 达到限制,取消剩余任务
-                    for f in future_to_pattern:
-                        f.cancel()
-                    break
-            except Exception:
-                # 单个模式失败不影响其他模式
-                pass
+    if not compiled_patterns:
+        return []
 
-    return all_results[:limit]
+    # 单次遍历搜索: 所有模式在一次文件遍历中完成
+    matches = workspace.search_content_multi_pattern(
+        patterns=compiled_patterns,
+        folder_path=search_path,
+        file_pattern=file_pattern,
+        max_workers=4,
+        ignore=ignore,
+    )
+
+    if not matches:
+        return []
+
+    # 应用 limit 截断
+    matches = matches[:limit]
+
+    # 按文件分组并构建带上下文的结果
+    return _build_results_with_context(matches, context_lines, symbol_name, workspace.root_path)
+
+
+def _build_results_with_context(
+    matches: list[dict],
+    context_lines: int,
+    symbol_name: str,
+    root_path: Path,
+) -> list[dict]:
+    """从扁平匹配列表构建按文件分组、带上下文的结果"""
+    context_lines = max(0, context_lines)
+
+    # 按文件分组, 保留首次出现的顺序
+    file_matches: dict[str, list[dict]] = {}
+    file_order: list[str] = []
+    for m in matches:
+        f = m["file"]
+        if f not in file_matches:
+            file_matches[f] = []
+            file_order.append(f)
+        file_matches[f].append(m)
+
+    results = []
+    for file_rel in file_order:
+        file_match_list = file_matches[file_rel]
+
+        # 收集需要读取的行号范围(匹配行 ± 上下文行)
+        needed_lines: set[int] = set()
+        for m in file_match_list:
+            for delta in range(-context_lines, context_lines + 1):
+                needed_lines.add(m["line_num"] + delta)
+
+        # 仅读取需要的行(不加载整个文件到内存)
+        line_cache: dict[int, str] = {}
+        file_full_path = root_path / file_rel
+        try:
+            if needed_lines:
+                max_needed = max(needed_lines)
+                with open(file_full_path, encoding="utf-8") as f:
+                    for line_num, line in enumerate(f, 1):
+                        if line_num in needed_lines:
+                            line_cache[line_num] = line.rstrip("\n\r")
+                        if line_num >= max_needed:
+                            break
+        except UnicodeDecodeError, PermissionError, OSError:
+            pass
+
+        # 为每个匹配项构建上下文
+        built_matches = []
+        for m in file_match_list:
+            match_line_num = m["line_num"]
+            context = []
+            for delta in range(-context_lines, context_lines + 1):
+                ctx_line_num = match_line_num + delta
+                if ctx_line_num in line_cache:
+                    context.append(
+                        {
+                            "line_num": ctx_line_num,
+                            "content": line_cache[ctx_line_num],
+                            "is_match": delta == 0,
+                        }
+                    )
+
+            built_matches.append(
+                {
+                    "line_num": match_line_num,
+                    "content": m["content"],
+                    "context": context,
+                    "match_type": m["pattern_type"],
+                    "symbol_name": symbol_name,
+                }
+            )
+
+        results.append(
+            {
+                "file": file_rel,
+                "matches": built_matches,
+                "type": file_match_list[0]["pattern_type"],
+            }
+        )
+
+    return results
 
 
 def _detect_language(search_path: Path, specified_lang: str) -> str:
@@ -394,7 +402,7 @@ class SymbolRefTool(BaseTool):
             return f"无法为符号 '{symbol_name}' 生成有效的搜索模式(语言: {detected_lang})"
 
         # 使用并发搜索执行所有模式
-        all_results = _search_patterns_concurrent(
+        all_results = _search_all_patterns(
             self.workspace,
             patterns,
             path,

--- a/src/workspace/workspace.py
+++ b/src/workspace/workspace.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from src.models.tool_error_response import ToolErrorResponse
 from src.workspace.path_validator import PathNotFoundError, PathValidator, WorkspaceBoundaryError
 
+# 默认排除的目录 后续改为从项目配置加载
+DEFAULT_EXCLUDED_DIRS = {".git", "__pycache__", "node_modules", ".venv", "venv", "dist", "build", ".idea", ".vscode"}
+
 
 def _highlight_matches(line: str, regex: re.Pattern) -> str:
     """
@@ -73,7 +76,7 @@ class Workspace:
             path = self.path_validator.validate(folder_path)
 
             # 初始化排除目录集合
-            exclude_set = set(exclude_dirs or [".git", "__pycache__", "node_modules", ".venv", "venv", "dist", "build"])
+            exclude_set = set(exclude_dirs or DEFAULT_EXCLUDED_DIRS)
 
             # 编译正则表达式
             flags = 0 if case_sensitive else re.IGNORECASE
@@ -171,6 +174,119 @@ class Workspace:
                         results.append((relative_path, line_num, line.rstrip("\n\r")))
         except UnicodeDecodeError, PermissionError:
             # 跳过无法读取的二进制文件或无权限的文件
+            pass
+        except Exception:
+            pass
+
+        return results
+
+    def search_content_multi_pattern(
+        self,
+        patterns: list[tuple[re.Pattern, str]],
+        folder_path: str = ".",
+        file_pattern: str = "*",
+        max_workers: int = 4,
+        ignore: list[str] | None = None,
+    ) -> list[dict]:
+        """单次文件遍历匹配多个正则模式, 直接返回结构化数据.
+
+        与 search_content 的区别:
+        - 接受多个已编译的正则 + 类型标签, 一次遍历全部匹配
+        - 返回结构化 list[dict] 而非格式化字符串, 消除下游正则解析反模式
+        - 不做高亮处理(高亮是展示层关注点, 不应混入数据层)
+
+        Args:
+            patterns: [(compiled_regex, type_label), ...] 已编译正则及其类型标签
+            folder_path: 搜索起始路径
+            file_pattern: 文件通配符(如 "*.py")
+            max_workers: 并发读取文件的线程数
+            ignore: 忽略路径正则列表
+
+        Returns:
+            [{"file": str, "line_num": int, "content": str, "pattern_type": str}, ...]
+            按文件路径 → 行号排序, 同一行多个模式匹配则每个各一条记录
+        """
+        try:
+            path = self.path_validator.validate(folder_path)
+
+            # 预编译 ignore 正则
+            ignore_res: list[re.Pattern] = []
+            if ignore:
+                for ign in ignore:
+                    try:
+                        ignore_res.append(re.compile(ign))
+                    except re.error:
+                        continue
+
+            # 收集文件(一次遍历)
+            files_to_search: list[Path] = []
+            if path.is_file():
+                files_to_search = [path]
+            else:
+                for file_path in path.rglob(file_pattern):
+                    if file_path.is_file():
+                        if any(p.name in DEFAULT_EXCLUDED_DIRS for p in file_path.parents):
+                            continue
+                        rel = str(file_path.relative_to(self.root_path))
+                        if any(ir.search(rel) for ir in ignore_res):
+                            continue
+                        files_to_search.append(file_path)
+
+            if not files_to_search:
+                return []
+
+            # 并发搜索所有文件, 每个文件内一次读取、一次测试所有模式
+            all_matches: list[dict] = []
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = {
+                    executor.submit(self._search_multi_in_file, file_path, patterns): file_path
+                    for file_path in files_to_search
+                }
+                for future in as_completed(futures):
+                    try:
+                        file_results = future.result()
+                        if file_results:
+                            all_matches.extend(file_results)
+                    except Exception:
+                        pass
+
+            # 按文件路径 → 行号排序
+            all_matches.sort(key=lambda m: (m["file"], m["line_num"]))
+            return all_matches
+
+        except PathNotFoundError, WorkspaceBoundaryError, PermissionError:
+            return []
+        except Exception:
+            return []
+
+    def _search_multi_in_file(self, file_path: Path, patterns: list[tuple[re.Pattern, str]]) -> list[dict]:
+        """在单个文件中一次读取、逐行测试所有模式.
+
+        Args:
+            file_path: 文件绝对路径
+            patterns: [(compiled_regex, type_label), ...]
+
+        Returns:
+            匹配项列表, 同一行多个模式匹配时每个各返回一条
+        """
+        results: list[dict] = []
+        relative_path = str(file_path.relative_to(self.root_path))
+
+        try:
+            with open(file_path, encoding="utf-8") as f:
+                for line_num, line in enumerate(f, 1):
+                    stripped = line.rstrip("\n\r")
+                    for regex, pattern_type in patterns:
+                        if regex.search(stripped):
+                            results.append(
+                                {
+                                    "file": relative_path,
+                                    "line_num": line_num,
+                                    "content": stripped,
+                                    "pattern_type": pattern_type,
+                                }
+                            )
+        except UnicodeDecodeError, PermissionError:
             pass
         except Exception:
             pass


### PR DESCRIPTION
- 修复问题: 消除多模式搜索导致的文件系统重复遍历与 I/O 瓶颈
  * 移除 `_search_single_pattern` 和 `_search_patterns_concurrent`，引入 `_search_all_patterns` 实现单次文件遍历匹配所有正则
  * 调用 `Workspace.search_content_multi_pattern` API 替代旧版 `search_content`，避免 N 次 (N=模式数量) 重复打开文件
  * 优化 `_build_results_with_context` 逻辑，按需读取文件行缓存而非全量加载，解决大文件内存溢出风险
- 重构优化: 修正上下文行获取逻辑与数据格式处理
  * 将匹配结果从非结构化文本字符串解析重构为原生 `list[dict]` 数据结构，消除“格式化→正则解析”的反模式
  * 修复上下文行计算逻辑，支持精确获取匹配行前后指定行数 (`context_lines`) 的原始内容
  * 增加正则预编译与无效模式过滤机制，提升搜索执行效率
- 破坏性变更: 底层搜索接口返回结构变更
  * `symbol_ref_tool` 不再依赖 `Workspace.search_content` 的格式化字符串输出，转而使用 `search_content_multi_pattern` 的结构化字典列表
  * 移除了对 `[文件] path\n----\n` 文本格式的解析代码，下游需适配新的 `file`, `line_num`, `content`, `pattern_type` 字段