### PR TITLE
feat(#134): 为 exact_search 添加 file_pattern 参数并修复 limit 语义 / Add file_…

### DIFF
--- a/src/workspace/tools/exact_search_tool.py
+++ b/src/workspace/tools/exact_search_tool.py
@@ -81,6 +81,7 @@ class ExactSearchTool(BaseTool):
             "path": "搜索文件或文件夹路径",
             "case_sensitive": "是否大小写敏感",
             "whole_word": "是否全词匹配",
+            "file_pattern": "文件匹配模式,支持通配符",
             "limit": "最大匹配数量限制",
             "ignore": "忽略匹配正则的文件或文件夹列表",
         }
@@ -92,6 +93,7 @@ class ExactSearchTool(BaseTool):
         path: str = ".",
         case_sensitive: bool = True,
         whole_word: bool = True,
+        file_pattern: str = "*",
         limit: int = 256,
         ignore: list[str] | None = None,
     ) -> str:
@@ -114,16 +116,17 @@ class ExactSearchTool(BaseTool):
         # 搜索结果
         results = []
         file_count = 0
+        total_matches = 0
 
         # 确定要搜索的文件列表(支持单文件或目录)
-        files_to_search = [search_path] if search_path.is_file() else list(search_path.rglob("*"))
+        files_to_search = [search_path] if search_path.is_file() else list(search_path.rglob(file_pattern))
 
         # 遍历所有文件
         for file_path in files_to_search:
             if not file_path.is_file():
                 continue
             # 检查是否达到限制
-            if len(results) >= limit:
+            if total_matches >= limit:
                 break
 
             # 检查是否应该忽略
@@ -149,6 +152,7 @@ class ExactSearchTool(BaseTool):
                 if file_matches:
                     results.append({"file": str(file_path), "matches": file_matches})
                     file_count += 1
+                    total_matches += len(file_matches)
 
             except OSError, UnicodeDecodeError, PermissionError:
                 continue  # 跳过无法读取的文件

--- a/src/workspace/tools/regex_search_tool.py
+++ b/src/workspace/tools/regex_search_tool.py
@@ -144,6 +144,7 @@ class RegexSearchTool(BaseTool):
         # 搜索结果
         results = []
         file_count = 0
+        total_matches = 0
 
         # 确定要搜索的文件列表(支持单文件或目录)
         files_to_search = [search_path] if search_path.is_file() else list(search_path.rglob(file_pattern))
@@ -153,7 +154,7 @@ class RegexSearchTool(BaseTool):
             if not file_path.is_file():
                 continue
             # 检查是否达到限制
-            if len(results) >= limit:
+            if total_matches >= limit:
                 break
 
             # 检查是否应该忽略该文件或文件夹
@@ -180,6 +181,7 @@ class RegexSearchTool(BaseTool):
                 if file_results:
                     results.append({"file": str(file_path), "matches": file_results})
                     file_count += 1
+                    total_matches += len(file_results)
 
             except OSError, UnicodeDecodeError, PermissionError:
                 continue  # 跳过无法读取的文件


### PR DESCRIPTION
…pattern parameter and fix limit semantics

- 为 exact_search 添加 file_pattern 参数,默认 "*" 保持向后兼容
- 将 limit 语义从"扫描文件数"改为"返回匹配项数",同步修复 regex_search
- Replace hardcoded rglob("*") with rglob(file_pattern)
- Change limit to count individual matches instead of files scanned